### PR TITLE
Add tab-manager-extension scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # codex-studio
+
+Monorepo for Codex Studio projects.
+
+## Categories
+
+### Extensions
+- [tab-manager-extension](extensions/tab-manager-extension)

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,0 +1,6 @@
+# Extensions
+
+This directory contains browser extensions for Codex Studio.
+
+Projects:
+- [tab-manager-extension](tab-manager-extension/)

--- a/extensions/tab-manager-extension/README.md
+++ b/extensions/tab-manager-extension/README.md
@@ -1,0 +1,19 @@
+# tab-manager-extension
+
+A basic Chrome extension template for managing browser tabs.
+
+## Development
+
+Install dependencies (if any) and build:
+
+```bash
+npm install
+npm run build
+```
+
+The built extension is placed in the `dist/` directory.
+
+## Load Unpacked Extension
+
+Open Chrome's Extensions page, enable Developer mode and click **Load unpacked**.
+Select the `dist/` folder of this project.

--- a/extensions/tab-manager-extension/dist/manifest.json
+++ b/extensions/tab-manager-extension/dist/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 3,
+  "name": "Tab Manager",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["tabs"]
+}

--- a/extensions/tab-manager-extension/dist/popup.html
+++ b/extensions/tab-manager-extension/dist/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Tab Manager</title>
+</head>
+<body>
+  <h1>Tab Manager</h1>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extensions/tab-manager-extension/dist/popup.js
+++ b/extensions/tab-manager-extension/dist/popup.js
@@ -1,0 +1,2 @@
+// TODO: implement popup logic
+console.log('Tab Manager extension loaded');

--- a/extensions/tab-manager-extension/manifest.json
+++ b/extensions/tab-manager-extension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 3,
+  "name": "Tab Manager",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["tabs"]
+}

--- a/extensions/tab-manager-extension/popup.html
+++ b/extensions/tab-manager-extension/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Tab Manager</title>
+</head>
+<body>
+  <h1>Tab Manager</h1>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extensions/tab-manager-extension/src/popup.js
+++ b/extensions/tab-manager-extension/src/popup.js
@@ -1,0 +1,2 @@
+// TODO: implement popup logic
+console.log('Tab Manager extension loaded');


### PR DESCRIPTION
## Summary
- scaffold `extensions/tab-manager-extension` with basic Chrome extension files
- add category-level README in `extensions`
- update root README with Extensions section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68882c66d0948327a84931b766d8d143