### PR TITLE
Add NexusForge control room GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
-# codex-studio
+# NexusForge Control Room
 
-Monorepo for Codex Studio projects.
+Control Room provides a lightweight GUI to observe the NexusForge build
+pipeline and queue interventions.
 
-## Categories
+## Run
 
-### Extensions
-- [tab-manager-extension](extensions/tab-manager-extension)
+```sh
+docker compose up --build
+```
+
+The container bind-mounts `~/NexusForge` to `/workspace` and listens on
+http://localhost:3000.
+
+## Workspace
+
+The GUI reads from `/workspace/.nexusforge`:
+- `state.json` – build state
+- `run.log` – append-only log
+- `checklist.md` – acceptance checks
+- `patches/` – diff files
+- `policy.json` – DeepSeek policy
+- `commands/queue.jsonl` – command queue (append only)
+
+POSTing to `/api/commands` appends a JSON line to the command queue for an
+external orchestrator to handle.

--- a/control-room/.dockerignore
+++ b/control-room/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/control-room/Dockerfile
+++ b/control-room/Dockerfile
@@ -1,0 +1,9 @@
+FROM node
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --quiet || npm install --quiet
+COPY . .
+RUN npm run build
+USER node
+EXPOSE 3000
+CMD ["npm","run","start"]

--- a/control-room/next.config.js
+++ b/control-room/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = { experimental: { appDir: true } };
+module.exports = nextConfig;

--- a/control-room/package.json
+++ b/control-room/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "nexusforge-control-room",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "*",
+    "react": "*",
+    "react-dom": "*",
+    "tailwindcss": "*",
+    "postcss": "*",
+    "autoprefixer": "*"
+  },
+  "devDependencies": {
+    "typescript": "*",
+    "ts-node": "*",
+    "ts-jest": "*",
+    "jest": "*",
+    "@types/node": "*",
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "@types/jest": "*"
+  },
+  "jest": {
+    "transform": {"^.+\\.(t|j)sx?$": "ts-jest"},
+    "testEnvironment": "node"
+  }
+}

--- a/control-room/postcss.config.js
+++ b/control-room/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/control-room/src/app/api/checks/route.ts
+++ b/control-room/src/app/api/checks/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { readText } from '@/lib/fs';
+
+export async function GET() {
+  const md = await readText('checklist.md');
+  const checks = md.split('\n').filter(Boolean).map(line => {
+    const m = line.match(/^- \[( |x)\] (.+)$/);
+    return { text: m ? m[2] : line, status: m ? (m[1] === 'x' ? 'done' : 'todo') : 'note' };
+  });
+  return NextResponse.json({ checks });
+}

--- a/control-room/src/app/api/commands/route.ts
+++ b/control-room/src/app/api/commands/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { appendCommand, readJson } from '@/lib/fs';
+
+const TYPES = [
+  'request_retry',
+  'request_rebuild_phase',
+  'pause_pipeline',
+  'resume_pipeline',
+  'open_patch',
+  'approve_overwrite',
+  'run_checks'
+];
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  if (!TYPES.includes(body.type)) {
+    return NextResponse.json({ error: 'invalid type' }, { status: 400 });
+  }
+  const state = await readJson('state.json', {});
+  const cmd = {
+    ts: new Date().toISOString(),
+    actor: 'gui',
+    type: body.type,
+    payload: body.payload || {},
+    blueprint_hash: state.blueprint_hash || ''
+  };
+  await appendCommand(cmd);
+  return NextResponse.json(cmd);
+}

--- a/control-room/src/app/api/log/stream/route.ts
+++ b/control-room/src/app/api/log/stream/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { tailStream } from '@/lib/fs';
+
+export async function GET() {
+  const stream = tailStream('run.log');
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/control-room/src/app/api/patches/[name]/route.ts
+++ b/control-room/src/app/api/patches/[name]/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { readText } from '@/lib/fs';
+
+export async function GET(_: Request, { params }: { params: { name: string } }) {
+  const text = await readText(`patches/${params.name}`);
+  return new NextResponse(text, { headers: { 'Content-Type': 'text/plain' } });
+}

--- a/control-room/src/app/api/patches/route.ts
+++ b/control-room/src/app/api/patches/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { listDir, safeJoin } from '@/lib/fs';
+import fs from 'fs';
+
+export async function GET() {
+  const dir = safeJoin('patches');
+  const files = await listDir('patches');
+  const list = files.map(name => ({ name, size: fs.statSync(safeJoin('patches', name)).size }));
+  return NextResponse.json(list);
+}

--- a/control-room/src/app/api/policy/route.ts
+++ b/control-room/src/app/api/policy/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { readJson } from '@/lib/fs';
+
+export async function GET() {
+  const policy = await readJson('policy.json', {});
+  return NextResponse.json(policy);
+}

--- a/control-room/src/app/api/state/route.ts
+++ b/control-room/src/app/api/state/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { readJson } from '@/lib/fs';
+
+export async function GET() {
+  const data = await readJson('state.json', {});
+  return NextResponse.json(data);
+}

--- a/control-room/src/app/errors/page.tsx
+++ b/control-room/src/app/errors/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ErrorsPage() {
+  const [errors, setErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch('/api/state').then(r => r.json()).then(s => {
+      setErrors(s.errors || []);
+    });
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl mb-2">Errors</h1>
+      <ul className="space-y-1">
+        {errors.map((e, i) => <li key={i} className="text-red-400">{e}</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/control-room/src/app/layout.tsx
+++ b/control-room/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import '../styles/globals.css';
+import { Topbar } from '@/components/Topbar';
+import { InterveneTray } from '@/components/InterveneTray';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="dark">
+      <body className="bg-gray-900 text-gray-100">
+        <Topbar />
+        <div className="p-4 min-h-screen">
+          {children}
+        </div>
+        <InterveneTray />
+      </body>
+    </html>
+  );
+}

--- a/control-room/src/app/page.tsx
+++ b/control-room/src/app/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { useEffect, useState } from 'react';
+import ProgressBoard from '@/components/ProgressBoard';
+import LiveLog from '@/components/LiveLog';
+import ChecksList from '@/components/ChecksList';
+
+export default function Page() {
+  const [state, setState] = useState<any>({});
+  const [checks, setChecks] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch('/api/state').then(r => r.json()).then(setState);
+    fetch('/api/checks').then(r => r.json()).then(d => setChecks(d.checks || []));
+  }, []);
+
+  return (
+    <main className="space-y-4">
+      <ProgressBoard data={state} />
+      <ChecksList checks={checks} />
+      <LiveLog />
+    </main>
+  );
+}

--- a/control-room/src/app/patches/page.tsx
+++ b/control-room/src/app/patches/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import PatchList from '@/components/PatchList';
+
+export default function PatchesPage() {
+  return (
+    <div>
+      <h1 className="text-xl mb-2">Patches</h1>
+      <PatchList />
+    </div>
+  );
+}

--- a/control-room/src/app/policy/page.tsx
+++ b/control-room/src/app/policy/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function PolicyPage() {
+  const [policy, setPolicy] = useState<any>({});
+
+  useEffect(() => {
+    fetch('/api/policy').then(r => r.json()).then(setPolicy);
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <h1 className="text-xl">Policy</h1>
+      <pre className="bg-gray-800 p-2 overflow-auto text-sm">{JSON.stringify(policy, null, 2)}</pre>
+      <div className="text-sm text-gray-400">
+        <ul className="list-disc ml-4">
+          <li>model_for_code = deepseek-chat</li>
+          <li>temperature = 0.0</li>
+          <li>response_format = {`{"type":"json_object"}`}</li>
+          <li>stable system preface / context caching enabled</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/control-room/src/components/ChecksList.tsx
+++ b/control-room/src/components/ChecksList.tsx
@@ -1,0 +1,12 @@
+export default function ChecksList({ checks }: { checks: any[] }) {
+  return (
+    <ul className="space-y-1">
+      {checks.map((c, i) => (
+        <li key={i} className="flex items-center space-x-2">
+          <span>{c.status === 'done' ? '✅' : c.status === 'fail' ? '❌' : '⬜'}</span>
+          <span>{c.text}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/control-room/src/components/InterveneTray.tsx
+++ b/control-room/src/components/InterveneTray.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+const TYPES = [
+  'request_retry',
+  'request_rebuild_phase',
+  'pause_pipeline',
+  'resume_pipeline',
+  'open_patch',
+  'approve_overwrite',
+  'run_checks'
+];
+
+export function InterveneTray() {
+  const [open, setOpen] = useState(false);
+  const [outbox, setOutbox] = useState<any[]>([]);
+
+  useEffect(() => {
+    const key = (e: KeyboardEvent) => {
+      if (e.key === 'p') setOpen((o) => !o);
+    };
+    window.addEventListener('keydown', key);
+    return () => window.removeEventListener('keydown', key);
+  }, []);
+
+  const send = async (type: string) => {
+    const res = await fetch('/api/commands', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type })
+    });
+    if (res.ok) {
+      const json = await res.json();
+      setOutbox((o) => [json, ...o]);
+    }
+  };
+
+  if (!open) return (
+    <button onClick={() => setOpen(true)} className="fixed bottom-2 right-2 bg-blue-600 text-white px-3 py-1 rounded">Intervene</button>
+  );
+
+  return (
+    <div className="fixed bottom-2 right-2 bg-gray-800 p-4 rounded shadow space-y-2 w-56">
+      <button onClick={() => setOpen(false)} className="absolute top-1 right-1">x</button>
+      {TYPES.map(t => (
+        <button key={t} onClick={() => send(t)} className="block w-full text-left hover:bg-gray-700 px-2">
+          {t}
+        </button>
+      ))}
+      <div className="mt-2 text-xs">Outbox:</div>
+      <ul className="max-h-24 overflow-y-auto text-xs">
+        {outbox.map((c, i) => <li key={i}>{c.type} – {c.ts}</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/control-room/src/components/LiveLog.tsx
+++ b/control-room/src/components/LiveLog.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+export default function LiveLog() {
+  const [paused, setPaused] = useState(false);
+  const [lines, setLines] = useState<string[]>([]);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const es = new EventSource('/api/log/stream');
+    es.onmessage = (e) => {
+      if (!paused) setLines((l) => [...l.slice(-200), e.data]);
+    };
+    const key = (e: KeyboardEvent) => {
+      if (e.key === 'l') setPaused((p) => !p);
+    };
+    window.addEventListener('keydown', key);
+    return () => {
+      es.close();
+      window.removeEventListener('keydown', key);
+    };
+  }, [paused]);
+
+  useEffect(() => {
+    if (!paused) endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines, paused]);
+
+  return (
+    <div className="bg-black text-green-400 p-2 h-48 overflow-y-auto text-xs">
+      {lines.map((l, i) => <div key={i}>{l}</div>)}
+      <div ref={endRef} />
+    </div>
+  );
+}

--- a/control-room/src/components/PatchList.tsx
+++ b/control-room/src/components/PatchList.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function PatchList() {
+  const [list, setList] = useState<any[]>([]);
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    fetch('/api/patches').then(r => r.json()).then(setList);
+  }, []);
+
+  const open = async (name: string) => {
+    const txt = await fetch(`/api/patches/${name}`).then(r => r.text());
+    setContent(txt);
+  };
+
+  return (
+    <div className="flex space-x-4">
+      <ul className="w-1/3 space-y-1">
+        {list.map((p: any) => (
+          <li key={p.name}>
+            <button onClick={() => open(p.name)} className="underline">
+              {p.name} ({p.size})
+            </button>
+          </li>
+        ))}
+      </ul>
+      <pre className="flex-1 bg-gray-800 p-2 overflow-auto text-xs">{content}</pre>
+    </div>
+  );
+}

--- a/control-room/src/components/ProgressBoard.tsx
+++ b/control-room/src/components/ProgressBoard.tsx
@@ -1,0 +1,15 @@
+export default function ProgressBoard({ data }: { data: any }) {
+  const phases = data.phases || [];
+  return (
+    <div className="space-y-2">
+      {phases.map((p: any) => (
+        <div key={p.name}>
+          <div className="text-sm">{p.name}</div>
+          <div className="bg-gray-700 h-2 rounded">
+            <div className="bg-blue-500 h-2 rounded" style={{ width: `${p.progress || 0}%` }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/control-room/src/components/Topbar.tsx
+++ b/control-room/src/components/Topbar.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+export function Topbar() {
+  const search = useRef<HTMLInputElement>(null);
+  const [state, setState] = useState<any>({});
+
+  useEffect(() => {
+    fetch('/api/state').then(r => r.json()).then(setState);
+    const key = (e: KeyboardEvent) => {
+      if (e.key === '/') {
+        e.preventDefault();
+        search.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', key);
+    return () => window.removeEventListener('keydown', key);
+  }, []);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-2 bg-gray-800">
+      <div className="font-bold">NexusForge – {state.blueprint_hash || ''}</div>
+      <input ref={search} placeholder="Search" className="bg-gray-700 rounded px-2 py-1 text-sm" />
+    </div>
+  );
+}

--- a/control-room/src/lib/fs.ts
+++ b/control-room/src/lib/fs.ts
@@ -1,0 +1,74 @@
+import fs from 'fs';
+import path from 'path';
+
+const BASE = '/workspace/.nexusforge';
+
+export function safeJoin(...segs: string[]) {
+  const p = path.join(BASE, ...segs);
+  if (!p.startsWith(BASE)) throw new Error('bad path');
+  return p;
+}
+
+export async function readText(rel: string) {
+  const file = safeJoin(rel);
+  await fs.promises.mkdir(path.dirname(file), { recursive: true });
+  if (!fs.existsSync(file)) await fs.promises.writeFile(file, '');
+  return fs.promises.readFile(file, 'utf8');
+}
+
+export async function readJson(rel: string, def: any) {
+  const file = safeJoin(rel);
+  await fs.promises.mkdir(path.dirname(file), { recursive: true });
+  if (!fs.existsSync(file)) await fs.promises.writeFile(file, JSON.stringify(def, null, 2));
+  try {
+    return JSON.parse(await fs.promises.readFile(file, 'utf8'));
+  } catch {
+    return def;
+  }
+}
+
+export async function listDir(rel: string) {
+  const dir = safeJoin(rel);
+  await fs.promises.mkdir(dir, { recursive: true });
+  return fs.promises.readdir(dir);
+}
+
+export async function appendCommand(obj: any) {
+  const file = safeJoin('commands', 'queue.jsonl');
+  await fs.promises.mkdir(path.dirname(file), { recursive: true });
+  await fs.promises.appendFile(file, JSON.stringify(obj) + '\n');
+}
+
+export function sseFormat(line: string) {
+  return `data: ${line}\n\n`;
+}
+
+export function tailStream(rel: string) {
+  const file = safeJoin(rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  if (!fs.existsSync(file)) fs.writeFileSync(file, '');
+  let watcher: fs.FSWatcher;
+  let timer: NodeJS.Timeout;
+  let pos = 0;
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const send = (line: string) => controller.enqueue(encoder.encode(sseFormat(line)));
+      const readNew = () => {
+        fs.readFile(file, 'utf8', (err, data) => {
+          if (err) return;
+          const slice = data.slice(pos);
+          pos = data.length;
+          slice.split(/\n/).filter(Boolean).forEach(send);
+        });
+      };
+      readNew();
+      watcher = fs.watch(file, readNew);
+      timer = setInterval(readNew, 1000);
+    },
+    cancel() {
+      watcher?.close();
+      clearInterval(timer);
+    }
+  });
+}

--- a/control-room/src/styles/globals.css
+++ b/control-room/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/control-room/tailwind.config.ts
+++ b/control-room/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  darkMode: 'class',
+  plugins: [],
+};
+export default config;

--- a/control-room/tests/basic.spec.ts
+++ b/control-room/tests/basic.spec.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import { appendCommand, sseFormat } from '../src/lib/fs';
+
+describe('fs helpers', () => {
+  test('appendCommand writes json line', async () => {
+    const file = path.resolve('/workspace/.nexusforge/commands/queue.jsonl');
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+    await appendCommand({ foo: 'bar' });
+    const txt = fs.readFileSync(file, 'utf8').trim();
+    expect(JSON.parse(txt).foo).toBe('bar');
+  });
+
+  test('sseFormat', () => {
+    expect(sseFormat('hi')).toBe('data: hi\n\n');
+  });
+});

--- a/control-room/tsconfig.json
+++ b/control-room/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {"@/*": ["src/*"]}
+  },
+  "include": ["src", "tests"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  control-room:
+    build: ./control-room
+    ports:
+      - "3000:3000"
+    volumes:
+      - ${HOME}/NexusForge:/workspace
+    environment:
+      - NODE_ENV=production


### PR DESCRIPTION
## Summary
- add Dockerized Next.js control room for NexusForge
- expose APIs for state, logs, patches, policy and command queue
- provide dark-mode dashboard with live log stream and intervention tray

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f71fc0fc8327b128b43123883312