### PR TITLE
feat: add video intelligence dashboards

### DIFF
--- a/control-room/src/app/layout.tsx
+++ b/control-room/src/app/layout.tsx
@@ -5,9 +5,9 @@ import { InterveneTray } from '@/components/InterveneTray';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="dark">
-      <body className="bg-gray-900 text-gray-100">
+      <body className="min-h-screen bg-gray-950 text-gray-100">
         <Topbar />
-        <div className="p-4 min-h-screen">
+        <div className="px-4 pb-16 pt-8 sm:px-6">
           {children}
         </div>
         <InterveneTray />

--- a/control-room/src/app/page.tsx
+++ b/control-room/src/app/page.tsx
@@ -1,23 +1,30 @@
-'use client';
-import { useEffect, useState } from 'react';
-import ProgressBoard from '@/components/ProgressBoard';
-import LiveLog from '@/components/LiveLog';
-import ChecksList from '@/components/ChecksList';
+import { FaceGallery } from '@/components/FaceGallery';
+import { Timeline } from '@/components/Timeline';
+import { Wordcloud } from '@/components/Wordcloud';
+import { Spectrogram } from '@/components/Spectrogram';
+import { SettingsPanel } from '@/components/SettingsPanel';
 
 export default function Page() {
-  const [state, setState] = useState<any>({});
-  const [checks, setChecks] = useState<any[]>([]);
-
-  useEffect(() => {
-    fetch('/api/state').then(r => r.json()).then(setState);
-    fetch('/api/checks').then(r => r.json()).then(d => setChecks(d.checks || []));
-  }, []);
-
   return (
-    <main className="space-y-4">
-      <ProgressBoard data={state} />
-      <ChecksList checks={checks} />
-      <LiveLog />
+    <main className="mx-auto flex max-w-7xl flex-col gap-6">
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-5">
+        <div className="xl:col-span-3">
+          <FaceGallery />
+        </div>
+        <div className="flex flex-col gap-6 xl:col-span-2">
+          <Spectrogram />
+          <SettingsPanel />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-5">
+        <div className="xl:col-span-3">
+          <Timeline />
+        </div>
+        <div className="xl:col-span-2">
+          <Wordcloud />
+        </div>
+      </div>
     </main>
   );
 }

--- a/control-room/src/components/FaceGallery.tsx
+++ b/control-room/src/components/FaceGallery.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { FaceCluster } from '@/lib/api';
+import { getFaceClusters } from '@/lib/api';
+
+interface CompareSelection {
+  primary?: string;
+  secondary?: string;
+}
+
+export function FaceGallery() {
+  const [clusters, setClusters] = useState<FaceCluster[]>([]);
+  const [selectedClusterId, setSelectedClusterId] = useState<string | null>(null);
+  const [compareSelection, setCompareSelection] = useState<CompareSelection>({});
+
+  useEffect(() => {
+    let active = true;
+    getFaceClusters().then((data) => {
+      if (!active) return;
+      setClusters(data);
+      if (!selectedClusterId && data.length > 0) {
+        setSelectedClusterId(data[0].id);
+      }
+    });
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const selectedCluster = useMemo(
+    () => clusters.find((cluster) => cluster.id === selectedClusterId) ?? null,
+    [clusters, selectedClusterId]
+  );
+
+  const toggleCompare = (appearanceId: string) => {
+    setCompareSelection((selection) => {
+      if (selection.primary === appearanceId) {
+        const { secondary } = selection;
+        return { primary: secondary, secondary: undefined };
+      }
+      if (selection.secondary === appearanceId) {
+        return { ...selection, secondary: undefined };
+      }
+      if (!selection.primary) {
+        return { primary: appearanceId };
+      }
+      if (!selection.secondary) {
+        return { ...selection, secondary: appearanceId };
+      }
+      return { primary: appearanceId, secondary: selection.primary };
+    });
+  };
+
+  const comparePair = useMemo(() => {
+    if (!selectedCluster) return [];
+    return selectedCluster.appearances.filter((appearance) =>
+      appearance.id === compareSelection.primary || appearance.id === compareSelection.secondary
+    );
+  }, [compareSelection.primary, compareSelection.secondary, selectedCluster]);
+
+  return (
+    <section className="rounded-2xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl shadow-black/20">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-50">Face Gallery</h2>
+          <p className="text-sm text-gray-400">Clustered recognitions with quick comparisons.</p>
+        </div>
+        <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+          {clusters.length} clusters
+        </span>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {clusters.map((cluster) => {
+          const isSelected = cluster.id === selectedClusterId;
+          return (
+            <button
+              key={cluster.id}
+              type="button"
+              onClick={() => setSelectedClusterId(cluster.id)}
+              className={`group rounded-xl border px-4 py-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500/50 ${
+                isSelected
+                  ? 'border-emerald-500/50 bg-emerald-500/10 shadow-lg shadow-emerald-500/20'
+                  : 'border-gray-800 bg-gray-900/80 hover:border-gray-700'
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium text-gray-100">{cluster.label}</p>
+                  <p className="text-xs text-gray-400">Last seen {formatRelativeTime(cluster.lastSeen)}</p>
+                </div>
+                <div className="text-right text-xs text-gray-400">
+                  <div className="text-emerald-300">{Math.round(cluster.confidence * 100)}% match</div>
+                  <div>{cluster.appearances.length} appearances</div>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {cluster.appearances.slice(0, 4).map((appearance) => (
+                  <PreviewAvatar key={appearance.id} thumbnail={appearance.thumbnail} label={cluster.label} />
+                ))}
+                {cluster.appearances.length > 4 ? (
+                  <span className="rounded-full border border-gray-700 bg-gray-800 px-2 text-xs text-gray-400">
+                    +{cluster.appearances.length - 4}
+                  </span>
+                ) : null}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedCluster ? (
+        <div className="mt-6 space-y-4">
+          <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+            <div>
+              <h3 className="text-base font-semibold text-gray-50">Appearances for {selectedCluster.label}</h3>
+              <p className="text-sm text-gray-400">
+                Select up to two clips to launch a side-by-side comparison.
+              </p>
+            </div>
+            <div className="text-xs text-gray-500">
+              Confidence threshold {Math.round(selectedCluster.confidence * 100)}%
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {selectedCluster.appearances.map((appearance) => {
+              const active =
+                compareSelection.primary === appearance.id || compareSelection.secondary === appearance.id;
+              return (
+                <button
+                  key={appearance.id}
+                  type="button"
+                  onClick={() => toggleCompare(appearance.id)}
+                  className={`flex flex-col gap-3 rounded-xl border bg-gray-950/50 p-4 text-left transition hover:border-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 ${
+                    active ? 'border-emerald-400/60 shadow-inner shadow-emerald-500/30' : 'border-gray-800'
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="relative h-20 w-20 overflow-hidden rounded-lg border border-gray-800 bg-gray-900">
+                      {appearance.thumbnail ? (
+                        <img
+                          src={appearance.thumbnail}
+                          alt={`${selectedCluster.label} at ${appearance.timecode}`}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center text-sm text-gray-500">
+                          {selectedCluster.label
+                            .split(' ')
+                            .map((part) => part[0])
+                            .join('')}
+                        </div>
+                      )}
+                      {active ? (
+                        <span className="absolute left-1 top-1 rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-semibold text-emerald-950">
+                          Selected
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="space-y-1 text-sm">
+                      <div className="font-medium text-gray-200">Timestamp {appearance.timecode}</div>
+                      <div className="text-gray-400">{appearance.context}</div>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+            {comparePair.length === 2 ? (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {comparePair.map((appearance) => (
+                  <div key={appearance.id} className="space-y-3 rounded-lg border border-emerald-500/20 bg-gray-950/60 p-3">
+                    <div className="flex items-center justify-between text-sm text-gray-400">
+                      <span>{appearance.timecode}</span>
+                      <span>{appearance.context}</span>
+                    </div>
+                    <div className="relative h-40 overflow-hidden rounded-md border border-gray-900 bg-gray-900">
+                      {appearance.thumbnail ? (
+                        <img
+                          src={appearance.thumbnail}
+                          alt={`${selectedCluster.label} reference frame`}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-sm text-gray-500">
+                          Frame unavailable
+                        </div>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      Confidence {Math.round(selectedCluster.confidence * 100)}% • Manual review enabled
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-emerald-200">
+                Choose two appearances above to open the rapid compare view. This view synchronises clips and surfaces
+                contextual metadata for manual validation.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function PreviewAvatar({ thumbnail, label }: { thumbnail?: string; label: string }) {
+  if (!thumbnail) {
+    const initials = label
+      .split(' ')
+      .map((part) => part[0])
+      .join('');
+    return (
+      <span className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-700 bg-gray-800 text-xs font-medium text-gray-200">
+        {initials}
+      </span>
+    );
+  }
+  return (
+    <span className="h-8 w-8 overflow-hidden rounded-full border border-gray-700">
+      <img src={thumbnail} alt={label} className="h-full w-full object-cover" />
+    </span>
+  );
+}
+
+function formatRelativeTime(isoDate: string) {
+  const now = new Date();
+  const target = new Date(isoDate);
+  const diff = Math.max(0, now.getTime() - target.getTime());
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hour ago';
+  if (hours < 24) return `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}

--- a/control-room/src/components/SettingsPanel.tsx
+++ b/control-room/src/components/SettingsPanel.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState, type ChangeEvent } from 'react';
+import type { PrivacySettings } from '@/lib/api';
+import { getPrivacySettings, updatePrivacySettings } from '@/lib/api';
+
+export function SettingsPanel() {
+  const [settings, setSettings] = useState<PrivacySettings | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getPrivacySettings().then((data) => {
+      if (!active) return;
+      setSettings(data);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const persist = async (next: PrivacySettings) => {
+    setSettings(next);
+    setIsSaving(true);
+    const saved = await updatePrivacySettings(next);
+    setSettings(saved);
+    setIsSaving(false);
+    setMessage('Settings saved');
+    setTimeout(() => setMessage(null), 2000);
+  };
+
+  if (!settings) {
+    return (
+      <section className="rounded-2xl border border-gray-800 bg-gray-900/70 p-6 text-sm text-gray-400 shadow-xl shadow-black/20">
+        Loading privacy settings…
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl shadow-black/20">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-50">Privacy &amp; Thresholds</h2>
+          <p className="text-sm text-gray-400">Manage automatic redaction and detection sensitivity.</p>
+        </div>
+        {message ? <span className="text-xs text-emerald-300">{message}</span> : null}
+      </header>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between gap-4 rounded-xl border border-gray-800 bg-gray-950/60 p-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-100">Automatic privacy blur</h3>
+            <p className="text-sm text-gray-400">Masks PII in live feeds before distribution.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => persist({ ...settings, privacyBlur: !settings.privacyBlur })}
+            className={`relative h-7 w-12 rounded-full border transition ${
+              settings.privacyBlur
+                ? 'border-emerald-500/60 bg-emerald-500/30'
+                : 'border-gray-700 bg-gray-800'
+            }`}
+          >
+            <span
+              className={`absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full bg-white transition ${
+                settings.privacyBlur ? 'translate-x-6 shadow-inner shadow-emerald-500/30' : 'translate-x-1 shadow'
+              }`}
+            />
+          </button>
+        </div>
+
+        <Slider
+          label="Recognition confidence"
+          description="Minimum score required before a face is considered a match."
+          value={settings.recognitionThreshold}
+          onChange={(value) => persist({ ...settings, recognitionThreshold: value })}
+        />
+
+        <Slider
+          label="Anomaly alert threshold"
+          description="Tune how sensitive the acoustic monitors are before pushing an alert."
+          value={settings.anomalyThreshold}
+          onChange={(value) => persist({ ...settings, anomalyThreshold: value })}
+        />
+      </div>
+      {isSaving ? <p className="mt-4 text-xs text-gray-500">Saving…</p> : null}
+    </section>
+  );
+}
+
+interface SliderProps {
+  label: string;
+  description: string;
+  value: number;
+  onChange: (next: number) => void;
+}
+
+function Slider({ label, description, value, onChange }: SliderProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const parsed = Number.parseFloat(event.target.value);
+    onChange(Number.isFinite(parsed) ? parsed : value);
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-gray-800 bg-gray-950/60 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-100">{label}</h3>
+          <p className="text-sm text-gray-400">{description}</p>
+        </div>
+        <span className="rounded-full border border-gray-800 bg-gray-900 px-2 py-1 text-xs text-gray-300">
+          {(value * 100).toFixed(0)}%
+        </span>
+      </div>
+      <input
+        type="range"
+        min={0.3}
+        max={0.99}
+        step={0.01}
+        value={value}
+        onChange={handleChange}
+        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-gray-800 accent-emerald-500"
+      />
+    </div>
+  );
+}

--- a/control-room/src/components/Spectrogram.tsx
+++ b/control-room/src/components/Spectrogram.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { SpectrogramTrack } from '@/lib/api';
+import { getSpectrograms } from '@/lib/api';
+
+const SEVERITY_COLORS: Record<string, string> = {
+  low: 'bg-emerald-500/80 border-emerald-400/80 text-emerald-950',
+  medium: 'bg-amber-400/90 border-amber-300/90 text-amber-950',
+  high: 'bg-rose-500/90 border-rose-400/90 text-rose-950'
+};
+
+export function Spectrogram() {
+  const [tracks, setTracks] = useState<SpectrogramTrack[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    getSpectrograms().then((data) => {
+      if (!active) return;
+      setTracks(data);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <section className="rounded-2xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl shadow-black/20">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-50">Spectrogram Monitor</h2>
+          <p className="text-sm text-gray-400">Acoustic and thermal overlays with flagged anomalies.</p>
+        </div>
+        <span className="text-xs text-gray-500">{tracks.length} tracks</span>
+      </header>
+      <div className="grid grid-cols-1 gap-4">
+        {tracks.map((track) => (
+          <article key={track.id} className="overflow-hidden rounded-xl border border-gray-800 bg-gray-950/60">
+            <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3 text-sm text-gray-300">
+              <div>
+                <h3 className="font-semibold text-gray-100">{track.label}</h3>
+                <p className="text-xs text-gray-500">Duration {track.durationSeconds}s</p>
+              </div>
+              <span className="rounded-full border border-gray-800 bg-gray-900 px-3 py-1 text-xs text-gray-400">
+                {track.anomalies.length} anomalies
+              </span>
+            </div>
+            <div className="relative">
+              <img src={track.imageUrl} alt={track.label} className="h-56 w-full object-cover" />
+              {track.anomalies.map((anomaly) => (
+                <span
+                  key={anomaly.id}
+                  className={`absolute flex -translate-x-1/2 translate-y-1/2 items-center gap-2 rounded-full border px-2 py-1 text-[11px] font-semibold shadow-lg shadow-black/30 ${
+                    SEVERITY_COLORS[anomaly.severity]
+                  }`}
+                  style={{ left: `${anomaly.time * 100}%`, bottom: `${anomaly.frequency * 100}%` }}
+                >
+                  <span className="h-2 w-2 rounded-full bg-current opacity-80" />
+                  {anomaly.label}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+        {tracks.length === 0 ? (
+          <div className="rounded-xl border border-gray-800 bg-gray-950/60 p-6 text-sm text-gray-400">
+            No spectrogram feeds connected.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/control-room/src/components/Timeline.tsx
+++ b/control-room/src/components/Timeline.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { TimelineSegment } from '@/lib/api';
+import { getTimelineSegments } from '@/lib/api';
+
+export function Timeline() {
+  const [segments, setSegments] = useState<TimelineSegment[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    getTimelineSegments().then((data) => {
+      if (!active) return;
+      setSegments(data);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <section className="h-full rounded-2xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl shadow-black/20">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-50">Scene Timeline</h2>
+          <p className="text-sm text-gray-400">Segmented detections with tracked entities.</p>
+        </div>
+        <span className="text-xs text-gray-500">{segments.length} segments</span>
+      </header>
+      <ol className="space-y-6">
+        {segments.map((segment, index) => (
+          <li key={segment.id} className="relative pl-8">
+            <span className="absolute left-0 top-1 flex h-5 w-5 items-center justify-center rounded-full border border-emerald-400/60 bg-emerald-500/10 text-xs text-emerald-300">
+              {index + 1}
+            </span>
+            <div className="flex flex-col gap-3 rounded-xl border border-gray-800 bg-gray-950/60 p-4">
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-400">
+                <span className="rounded bg-gray-800/70 px-2 py-0.5 font-medium text-gray-200">
+                  {segment.start} - {segment.end}
+                </span>
+                <span className="text-xs uppercase tracking-wide text-emerald-300">{segment.entities.length} detections</span>
+              </div>
+              <p className="text-sm text-gray-300">{segment.summary}</p>
+              <div className="flex flex-wrap gap-2">
+                {segment.entities.map((entity) => (
+                  <span
+                    key={entity.id}
+                    className="flex items-center gap-2 rounded-full border border-gray-700 bg-gray-900/80 px-3 py-1 text-xs text-gray-300"
+                  >
+                    <span>{entity.icon ?? getFallbackIcon(entity.type)}</span>
+                    <span className="font-medium text-gray-200">{entity.name}</span>
+                    <span className="text-[10px] uppercase tracking-wide text-gray-500">{entity.type}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          </li>
+        ))}
+        {segments.length === 0 ? (
+          <li className="rounded-xl border border-gray-800 bg-gray-950/60 p-6 text-sm text-gray-400">
+            Awaiting timeline data…
+          </li>
+        ) : null}
+      </ol>
+    </section>
+  );
+}
+
+function getFallbackIcon(type: string) {
+  switch (type) {
+    case 'person':
+      return '👤';
+    case 'vehicle':
+      return '🚗';
+    default:
+      return '🔍';
+  }
+}

--- a/control-room/src/components/Topbar.tsx
+++ b/control-room/src/components/Topbar.tsx
@@ -1,26 +1,71 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+
+import { useEffect, useMemo, useState } from 'react';
+import { getHealthStatus, type HealthStatus } from '@/lib/api';
+
+const STATUS_COPY: Record<HealthStatus['status'], { label: string; indicator: string }> = {
+  ok: { label: 'Operational', indicator: 'bg-emerald-400' },
+  degraded: { label: 'Degraded', indicator: 'bg-amber-400' },
+  down: { label: 'Offline', indicator: 'bg-rose-500' },
+  unknown: { label: 'Unknown', indicator: 'bg-gray-500' }
+};
 
 export function Topbar() {
-  const search = useRef<HTMLInputElement>(null);
-  const [state, setState] = useState<any>({});
+  const [health, setHealth] = useState<HealthStatus | null>(null);
 
   useEffect(() => {
-    fetch('/api/state').then(r => r.json()).then(setState);
-    const key = (e: KeyboardEvent) => {
-      if (e.key === '/') {
-        e.preventDefault();
-        search.current?.focus();
-      }
+    let active = true;
+    const load = async () => {
+      const data = await getHealthStatus();
+      if (!active) return;
+      setHealth(data);
     };
-    window.addEventListener('keydown', key);
-    return () => window.removeEventListener('keydown', key);
+    load();
+    const interval = window.setInterval(load, 20_000);
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
   }, []);
 
+  const status = health?.status ?? 'unknown';
+  const info = useMemo(() => STATUS_COPY[status], [status]);
+
   return (
-    <div className="flex items-center justify-between px-4 py-2 bg-gray-800">
-      <div className="font-bold">NexusForge – {state.blueprint_hash || ''}</div>
-      <input ref={search} placeholder="Search" className="bg-gray-700 rounded px-2 py-1 text-sm" />
-    </div>
+    <header className="border-b border-gray-800 bg-gray-950/80 shadow-lg shadow-black/10 backdrop-blur">
+      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-emerald-400">Sentinel Control Room</p>
+          <h1 className="text-xl font-semibold text-gray-100 sm:text-2xl">Video Intelligence Overview</h1>
+        </div>
+        <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:gap-4">
+          <div className="flex items-center gap-2 rounded-full border border-gray-800 bg-gray-900/80 px-3 py-1.5 text-sm text-gray-200">
+            <span className={`h-2.5 w-2.5 rounded-full ${info.indicator}`} aria-hidden />
+            <span>{info.label}</span>
+          </div>
+          <div className="text-xs text-gray-500">
+            {health ? `Last check ${formatRelativeTime(health.checkedAt)}` : 'Checking system health…'}
+          </div>
+        </div>
+      </div>
+    </header>
   );
+}
+
+function formatRelativeTime(isoDate: string) {
+  const now = new Date();
+  const target = new Date(isoDate);
+  const diff = Math.max(0, now.getTime() - target.getTime());
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hour ago';
+  if (hours < 24) return `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
 }

--- a/control-room/src/components/Wordcloud.tsx
+++ b/control-room/src/components/Wordcloud.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { getTranscript } from '@/lib/api';
+
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'has',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'to',
+  'was',
+  'were',
+  'with'
+]);
+
+type WordDatum = {
+  word: string;
+  weight: number;
+  count: number;
+};
+
+export function Wordcloud() {
+  const [transcript, setTranscript] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    getTranscript().then((text) => {
+      if (!active) return;
+      setTranscript(text);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const cloud = useMemo<WordDatum[]>(() => {
+    if (!transcript) return [];
+    const counts = new Map<string, number>();
+    transcript
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token && !STOP_WORDS.has(token))
+      .forEach((token) => {
+        counts.set(token, (counts.get(token) ?? 0) + 1);
+      });
+
+    const entries = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]).slice(0, 40);
+    const max = entries[0]?.[1] ?? 1;
+    return entries.map(([word, count]) => ({
+      word,
+      count,
+      weight: count / max
+    }));
+  }, [transcript]);
+
+  return (
+    <section className="rounded-2xl border border-gray-800 bg-gray-900/70 p-6 shadow-xl shadow-black/20">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-50">Transcript Wordcloud</h2>
+          <p className="text-sm text-gray-400">Highlights of frequently mentioned topics.</p>
+        </div>
+        <span className="text-xs text-gray-500">Top {cloud.length} terms</span>
+      </header>
+      {cloud.length > 0 ? (
+        <div className="flex flex-wrap gap-3">
+          {cloud.map(({ word, weight, count }) => (
+            <span
+              key={word}
+              className="rounded-full bg-gray-950/70 px-3 py-1 text-gray-200 shadow-md shadow-black/10"
+              style={{
+                fontSize: `${clamp(0.9, 1.8, weight * 1.8)}rem`,
+                opacity: clamp(0.55, 1, weight + 0.2)
+              }}
+              title={`${count} mentions`}
+            >
+              {word}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400">Transcript feed not yet available.</p>
+      )}
+    </section>
+  );
+}
+
+function clamp(min: number, max: number, value: number) {
+  return Math.max(min, Math.min(max, value));
+}

--- a/control-room/src/lib/api.ts
+++ b/control-room/src/lib/api.ts
@@ -1,0 +1,272 @@
+export type HealthStatus = {
+  status: 'ok' | 'degraded' | 'down' | 'unknown';
+  message?: string;
+  checkedAt: string;
+};
+
+export type FaceAppearance = {
+  id: string;
+  timecode: string;
+  context: string;
+  thumbnail?: string;
+};
+
+export type FaceCluster = {
+  id: string;
+  label: string;
+  confidence: number;
+  lastSeen: string;
+  appearances: FaceAppearance[];
+};
+
+export type TimelineEntity = {
+  id: string;
+  type: 'person' | 'object' | 'vehicle';
+  name: string;
+  icon?: string;
+};
+
+export type TimelineSegment = {
+  id: string;
+  start: string;
+  end: string;
+  summary: string;
+  entities: TimelineEntity[];
+};
+
+export type SpectrogramAnomaly = {
+  id: string;
+  label: string;
+  severity: 'low' | 'medium' | 'high';
+  /**
+   * Position on the horizontal axis expressed as a ratio (0 – 1).
+   */
+  time: number;
+  /**
+   * Position on the vertical axis expressed as a ratio (0 – 1).
+   */
+  frequency: number;
+};
+
+export type SpectrogramTrack = {
+  id: string;
+  label: string;
+  durationSeconds: number;
+  imageUrl: string;
+  anomalies: SpectrogramAnomaly[];
+};
+
+export type PrivacySettings = {
+  privacyBlur: boolean;
+  recognitionThreshold: number;
+  anomalyThreshold: number;
+};
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? '';
+
+async function safeFetch<T>(path: string, init?: RequestInit): Promise<T | null> {
+  try {
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {})
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    console.warn(`[api] request to ${path} failed`, error);
+    return null;
+  }
+}
+
+export async function getHealthStatus(): Promise<HealthStatus> {
+  const data = await safeFetch<HealthStatus>('/health');
+  if (data) {
+    return data;
+  }
+  return {
+    status: 'unknown',
+    message: 'No connection to backend',
+    checkedAt: new Date().toISOString()
+  };
+}
+
+export async function getFaceClusters(): Promise<FaceCluster[]> {
+  const data = await safeFetch<FaceCluster[]>('/api/face-clusters');
+  return data ?? fallbackFaceClusters;
+}
+
+export async function getTimelineSegments(): Promise<TimelineSegment[]> {
+  const data = await safeFetch<TimelineSegment[]>('/api/timeline');
+  return data ?? fallbackTimelineSegments;
+}
+
+export async function getTranscript(): Promise<string> {
+  const data = await safeFetch<{ transcript: string }>('/api/transcript');
+  if (data?.transcript) {
+    return data.transcript;
+  }
+  return fallbackTranscript;
+}
+
+export async function getSpectrograms(): Promise<SpectrogramTrack[]> {
+  const data = await safeFetch<SpectrogramTrack[]>('/api/spectrograms');
+  return data ?? fallbackSpectrograms;
+}
+
+export async function getPrivacySettings(): Promise<PrivacySettings> {
+  const data = await safeFetch<PrivacySettings>('/api/settings');
+  return data ?? fallbackPrivacySettings;
+}
+
+export async function updatePrivacySettings(next: PrivacySettings): Promise<PrivacySettings> {
+  const data = await safeFetch<PrivacySettings>('/api/settings', {
+    method: 'POST',
+    body: JSON.stringify(next)
+  });
+  return data ?? next;
+}
+
+const fallbackFaceClusters: FaceCluster[] = [
+  {
+    id: 'cluster-01',
+    label: 'Engineer – Elena Ruiz',
+    confidence: 0.92,
+    lastSeen: '2023-08-01T14:22:00Z',
+    appearances: [
+      {
+        id: 'appearance-01a',
+        timecode: '00:01:12',
+        context: 'Manufacturing floor, camera 3',
+        thumbnail:
+          'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96"><rect width="96" height="96" fill="%2371c7ec"/><text x="50%" y="55%" font-size="32" fill="%23000" text-anchor="middle">ER</text></svg>'
+      },
+      {
+        id: 'appearance-01b',
+        timecode: '00:17:45',
+        context: 'Loading dock, camera 6',
+        thumbnail:
+          'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96"><rect width="96" height="96" fill="%2326639b"/><text x="50%" y="55%" font-size="32" fill="%23fff" text-anchor="middle">ER</text></svg>'
+      },
+      {
+        id: 'appearance-01c',
+        timecode: '00:24:09',
+        context: 'Quality lab entrance',
+        thumbnail:
+          'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96"><rect width="96" height="96" fill="%237881f7"/><text x="50%" y="55%" font-size="32" fill="%23000" text-anchor="middle">ER</text></svg>'
+      }
+    ]
+  },
+  {
+    id: 'cluster-02',
+    label: 'Visitor – Unknown',
+    confidence: 0.61,
+    lastSeen: '2023-08-01T13:58:00Z',
+    appearances: [
+      {
+        id: 'appearance-02a',
+        timecode: '00:03:31',
+        context: 'Reception, camera 1'
+      },
+      {
+        id: 'appearance-02b',
+        timecode: '00:19:06',
+        context: 'R&D corridor'
+      }
+    ]
+  },
+  {
+    id: 'cluster-03',
+    label: 'Operator – Dylan Chen',
+    confidence: 0.88,
+    lastSeen: '2023-08-01T14:05:00Z',
+    appearances: [
+      {
+        id: 'appearance-03a',
+        timecode: '00:06:44',
+        context: 'Assembly cell 2'
+      },
+      {
+        id: 'appearance-03b',
+        timecode: '00:28:22',
+        context: 'Tool crib checkout'
+      }
+    ]
+  }
+];
+
+const fallbackTimelineSegments: TimelineSegment[] = [
+  {
+    id: 'segment-01',
+    start: '00:00:00',
+    end: '00:05:00',
+    summary: 'Shift change and access checks at facility entrance.',
+    entities: [
+      { id: 'person-elena', type: 'person', name: 'Elena Ruiz', icon: '👩‍🔧' },
+      { id: 'object-badge', type: 'object', name: 'Badge Scan', icon: '🪪' }
+    ]
+  },
+  {
+    id: 'segment-02',
+    start: '00:05:00',
+    end: '00:18:00',
+    summary: 'Assembly cell operating nominally. Forklift route flagged briefly.',
+    entities: [
+      { id: 'vehicle-forklift', type: 'vehicle', name: 'Forklift A2', icon: '🚜' },
+      { id: 'object-pallet', type: 'object', name: 'Pallet Stack', icon: '📦' }
+    ]
+  },
+  {
+    id: 'segment-03',
+    start: '00:18:00',
+    end: '00:30:00',
+    summary: 'Visitor escorted through R&D corridor. Late-stage QA prep begins.',
+    entities: [
+      { id: 'person-visitor', type: 'person', name: 'Unknown Visitor', icon: '🕵️' },
+      { id: 'person-escort', type: 'person', name: 'Security Lead', icon: '🛡️' },
+      { id: 'object-prototype', type: 'object', name: 'Prototype Case', icon: '💼' }
+    ]
+  }
+];
+
+const fallbackTranscript = `The morning shift transferred duties to the afternoon crew while security monitored for anomalies.
+Elena discussed calibration adjustments with Dylan near assembly cell two.
+A visiting client toured the research corridor accompanied by security.
+Quality assurance flagged a potential acoustic anomaly on line four for follow up.`;
+
+const fallbackSpectrograms: SpectrogramTrack[] = [
+  {
+    id: 'track-01',
+    label: 'Line 4 – Acoustic',
+    durationSeconds: 180,
+    imageUrl:
+      'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="512" height="160"><defs><linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" style="stop-color:%2309162d;stop-opacity:1"/><stop offset="100%" style="stop-color:%233855a6;stop-opacity:1"/></linearGradient></defs><rect width="512" height="160" fill="url(%23grad1)"/><circle cx="120" cy="40" r="18" fill="%2399f6ff" opacity="0.6"/><circle cx="320" cy="80" r="26" fill="%23fcd34d" opacity="0.6"/><circle cx="420" cy="120" r="20" fill="%23f472b6" opacity="0.6"/></svg>',
+    anomalies: [
+      { id: 'anomaly-01', label: 'Harmonic spike', severity: 'medium', time: 0.36, frequency: 0.25 },
+      { id: 'anomaly-02', label: 'Bearing resonance', severity: 'high', time: 0.62, frequency: 0.5 }
+    ]
+  },
+  {
+    id: 'track-02',
+    label: 'Compressor – Thermal',
+    durationSeconds: 95,
+    imageUrl:
+      'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="512" height="160"><defs><linearGradient id="grad2" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" style="stop-color:%2322253d;stop-opacity:1"/><stop offset="100%" style="stop-color:%2342568a;stop-opacity:1"/></linearGradient></defs><rect width="512" height="160" fill="url(%23grad2)"/><rect x="40" y="50" width="60" height="60" fill="%23fca5a5" opacity="0.6"/><rect x="260" y="20" width="90" height="90" fill="%238cddf5" opacity="0.6"/><rect x="400" y="70" width="70" height="70" fill="%23fde68a" opacity="0.6"/></svg>',
+    anomalies: [
+      { id: 'anomaly-03', label: 'Thermal bloom', severity: 'medium', time: 0.15, frequency: 0.7 }
+    ]
+  }
+];
+
+const fallbackPrivacySettings: PrivacySettings = {
+  privacyBlur: true,
+  recognitionThreshold: 0.76,
+  anomalyThreshold: 0.58
+};


### PR DESCRIPTION
## Summary
- add client api helpers with graceful fallbacks and expose health status polling
- introduce FaceGallery, Timeline, Wordcloud, Spectrogram, and Settings panels with dark shadcn-inspired styling
- refresh the main page layout and topbar to highlight the new dashboards and system state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc931cf5148327a543ae369a3740e6