### PR TITLE
Add vision inference wrappers for detection, faces, and scenes

### DIFF
--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,0 +1,1 @@
+"""Utility namespaces for FaceTrace packages."""

--- a/packages/vision/__init__.py
+++ b/packages/vision/__init__.py
@@ -1,0 +1,14 @@
+"""Vision utilities exposed by the FaceTrace stack."""
+
+from .detectors import Detection, YoloV8Detector
+from .faces import FaceEmbedding, InsightFacePipeline
+from .scenes import SceneCut, SceneCutDetector
+
+__all__ = [
+    "Detection",
+    "FaceEmbedding",
+    "InsightFacePipeline",
+    "SceneCut",
+    "SceneCutDetector",
+    "YoloV8Detector",
+]

--- a/packages/vision/_device.py
+++ b/packages/vision/_device.py
@@ -1,0 +1,67 @@
+"""Helpers for querying hardware tuning metadata from a device manager."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Mapping, Tuple
+
+LOGGER = logging.getLogger(__name__)
+
+
+def extract_mapping(value: Any) -> Mapping[str, Any]:
+    """Best-effort conversion of ``value`` into a mapping."""
+
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "_asdict"):
+        return value._asdict()
+    if hasattr(value, "__dict__"):
+        return value.__dict__
+    return {}
+
+
+def resolve_device_config(device_manager: Any, key: str) -> Mapping[str, Any]:
+    """Resolve tuning metadata for ``key`` from ``device_manager``."""
+
+    if device_manager is None:
+        return {}
+
+    if isinstance(device_manager, Mapping):
+        return device_manager
+
+    candidates: List[Tuple[str, Tuple[Any, ...], Dict[str, Any]]] = [
+        ("get_inference_config", (key,), {}),
+        ("get_detector_config", (key,), {}),
+        ("resolve", (key,), {}),
+        ("get", (key,), {}),
+        ("__call__", (key,), {}),
+        ("get", tuple(), {"name": key}),
+        ("resolve", tuple(), {"component": key}),
+    ]
+
+    for attr, args, kwargs in candidates:
+        method = getattr(device_manager, attr, None)
+        if not callable(method):
+            continue
+        try:
+            result = method(*args, **kwargs)
+        except TypeError:
+            try:
+                result = method(*args)
+            except Exception:  # pragma: no cover - defensive branch
+                continue
+        except Exception:  # pragma: no cover - defensive branch
+            LOGGER.debug("device_manager.%s raised an exception", attr, exc_info=True)
+            continue
+        mapping = extract_mapping(result)
+        if mapping:
+            return mapping
+
+    direct_mapping = extract_mapping(device_manager)
+    if direct_mapping:
+        return direct_mapping
+
+    return {}
+
+
+__all__ = ["extract_mapping", "resolve_device_config"]

--- a/packages/vision/detectors.py
+++ b/packages/vision/detectors.py
@@ -1,0 +1,279 @@
+"""Lightweight wrappers around YOLOv8 object detection.
+
+Example
+-------
+>>> import numpy as np
+>>> detector = YoloV8Detector("yolov8n.pt")
+>>> frame = np.zeros((640, 640, 3), dtype=np.uint8)
+>>> detections = detector.detect([frame])
+>>> print(len(detections[0]))
+"""
+
+from __future__ import annotations
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - only imported for typing
+    import numpy as np
+
+from ._device import resolve_device_config
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class VisionModelError(RuntimeError):
+    """Raised when a detector fails to execute inference."""
+
+
+@dataclass
+class BoundingBox:
+    """Axis aligned bounding box represented in corner format."""
+
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+    def as_tuple(self) -> Tuple[float, float, float, float]:
+        """Return the bounding box coordinates as ``(x1, y1, x2, y2)``."""
+
+        return (self.x1, self.y1, self.x2, self.y2)
+
+    def width(self) -> float:
+        """Width of the bounding box."""
+
+        return float(self.x2 - self.x1)
+
+    def height(self) -> float:
+        """Height of the bounding box."""
+
+        return float(self.y2 - self.y1)
+
+
+@dataclass
+class Detection:
+    """Structured detection output."""
+
+    bbox: BoundingBox
+    score: float
+    label: str
+    track_id: Optional[int] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+class YoloV8Detector:
+    """YOLOv8 detector wrapper that honours hardware tuning.
+
+    Parameters
+    ----------
+    model_path:
+        Local path to a YOLOv8 weights file understood by :mod:`ultralytics`.
+    device:
+        Device specifier forwarded to :meth:`ultralytics.YOLO.predict` (``"cpu"``
+        by default).
+    device_manager:
+        Optional hardware tuner used to determine optimal ``image_size`` and
+        ``batch_size``. The object is probed for ``get_inference_config``,
+        ``resolve`` or ``get`` style methods before falling back to plain
+        attribute access.
+    confidence:
+        Confidence threshold passed to the detector.
+    iou:
+        Intersection over union threshold used during non-maximum suppression.
+    max_attempts:
+        Number of inference retries before raising :class:`VisionModelError`.
+    timeout:
+        Maximum number of seconds allowed for all retries combined. ``None``
+        disables the timeout.
+
+    Example
+    -------
+    >>> from packages.vision.detectors import YoloV8Detector
+    >>> detector = YoloV8Detector("yolov8n.pt")
+    >>> dummy = [np.zeros((640, 640, 3), dtype=np.uint8)]  # doctest: +SKIP
+    >>> results = detector.detect(dummy)  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        model_path: Union[str, "os.PathLike[str]"],
+        *,
+        device: Optional[str] = None,
+        device_manager: Optional[Any] = None,
+        confidence: float = 0.25,
+        iou: float = 0.45,
+        max_attempts: int = 3,
+        timeout: Optional[float] = 10.0,
+        detection_kwargs: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.model_path = str(model_path)
+        self.device = device
+        self.confidence = float(confidence)
+        self.iou = float(iou)
+        self.max_attempts = max(1, int(max_attempts))
+        self.timeout = timeout
+        self._detection_kwargs = dict(detection_kwargs or {})
+
+        config = resolve_device_config(device_manager, "yolov8")
+        self._image_size = _coerce_int(config.get("image_size"), 640)
+        batch_value = config.get("batch_size", config.get("batch"))
+        self._batch_size = max(1, _coerce_int(batch_value, 1))
+
+        self._model = None
+        self._model_lock = threading.Lock()
+
+    def _ensure_model(self) -> Any:
+        if self._model is not None:
+            return self._model
+
+        with self._model_lock:
+            if self._model is None:
+                self._model = self._load_model()
+        return self._model
+
+    def _load_model(self) -> Any:
+        try:
+            from ultralytics import YOLO  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise VisionModelError("ultralytics is required for YOLOv8 inference") from exc
+
+        try:
+            model = YOLO(self.model_path)
+        except Exception as exc:
+            raise VisionModelError(f"Failed to load YOLOv8 weights from {self.model_path!r}") from exc
+
+        if self.device:
+            try:
+                model.to(self.device)
+            except Exception:  # pragma: no cover - best effort on optional dependency
+                LOGGER.debug("Failed to move YOLO model to %s", self.device, exc_info=True)
+
+        return model
+
+    @staticmethod
+    def _normalize_inputs(frames: Union[Sequence[Any], Any]) -> List[Any]:
+        if isinstance(frames, Sequence) and not isinstance(frames, (bytes, bytearray, str)):
+            return list(frames)
+
+        return [frames]
+
+    @staticmethod
+    def _tensor_to_list(value: Any) -> List[float]:
+        if value is None:
+            return []
+        if hasattr(value, "detach"):
+            value = value.detach()
+        if hasattr(value, "cpu"):
+            value = value.cpu()
+        if hasattr(value, "numpy"):
+            value = value.numpy()
+        if hasattr(value, "tolist"):
+            return value.tolist()
+        if isinstance(value, Iterable):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def _convert_result(self, result: Any) -> List[Detection]:
+        boxes = getattr(result, "boxes", None)
+        labels: List[str] = []
+        confidences: List[float] = []
+        tracker_ids: List[Optional[int]] = []
+        coordinates: List[List[float]] = []
+
+        if boxes is not None:
+            coordinates = self._tensor_to_list(getattr(boxes, "xyxy", None))
+            confidences = [float(x) for x in self._tensor_to_list(getattr(boxes, "conf", None))]
+            raw_labels = self._tensor_to_list(getattr(boxes, "cls", None))
+            tracker_ids = [int(x) if x is not None else None for x in getattr(boxes, "id", [None] * len(raw_labels))]
+
+            names = getattr(result, "names", None)
+            if names is None and hasattr(result, "model"):
+                names = getattr(result.model, "names", None)
+            if names is None and hasattr(self._model, "names"):
+                names = getattr(self._model, "names")
+
+            label_map: Mapping[int, str]
+            if isinstance(names, Mapping):
+                label_map = {int(k): str(v) for k, v in names.items()}
+            elif isinstance(names, Sequence):
+                label_map = {idx: str(name) for idx, name in enumerate(names)}
+            else:
+                label_map = {}
+
+            labels = [label_map.get(int(idx), str(int(idx))) for idx in raw_labels]
+        elif isinstance(result, Sequence):  # Raw dictionary-like output
+            for item in result:
+                if not isinstance(item, Mapping):
+                    continue
+                bbox = item.get("bbox") or item.get("box")
+                if bbox is None:
+                    continue
+                coordinates.append([float(v) for v in bbox])
+                confidences.append(float(item.get("confidence", item.get("score", 0.0))))
+                labels.append(str(item.get("label", "0")))
+                tracker_ids.append(item.get("track_id"))
+        else:  # pragma: no cover - fall back path for unexpected structure
+            LOGGER.debug("Unknown YOLO result format: %s", type(result))
+
+        detections: List[Detection] = []
+        for idx, coord in enumerate(coordinates):
+            if len(coord) < 4:
+                continue
+            bbox = BoundingBox(*[float(v) for v in coord[:4]])
+            score = confidences[idx] if idx < len(confidences) else 0.0
+            label = labels[idx] if idx < len(labels) else "0"
+            track_id = tracker_ids[idx] if idx < len(tracker_ids) else None
+            detections.append(Detection(bbox=bbox, score=score, label=label, track_id=track_id))
+        return detections
+
+    def detect(self, frames: Union[Sequence[Any], Any]) -> List[List[Detection]]:
+        """Run batched detection with retry & timeout safety."""
+
+        inputs = self._normalize_inputs(frames)
+
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        attempts = 0
+        last_error: Optional[Exception] = None
+
+        while attempts < self.max_attempts:
+            attempts += 1
+            try:
+                model = self._ensure_model()
+                predictions = model.predict(  # type: ignore[operator]
+                    inputs,
+                    imgsz=self._image_size,
+                    batch=self._batch_size,
+                    device=self.device,
+                    conf=self.confidence,
+                    iou=self.iou,
+                    verbose=False,
+                    **self._detection_kwargs,
+                )
+                return [self._convert_result(result) for result in predictions]
+            except Exception as exc:  # pragma: no cover - depends on runtime errors
+                last_error = exc
+                LOGGER.debug("YOLOv8 inference failed (attempt %s/%s)", attempts, self.max_attempts, exc_info=True)
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
+                if attempts >= self.max_attempts:
+                    break
+                time.sleep(min(0.5 * attempts, 1.5))
+
+        raise VisionModelError("YOLOv8 inference failed") from last_error
+
+    def __call__(self, frames: Union[Sequence[Any], Any]) -> List[List[Detection]]:
+        return self.detect(frames)
+
+
+__all__ = ["BoundingBox", "Detection", "VisionModelError", "YoloV8Detector"]

--- a/packages/vision/faces.py
+++ b/packages/vision/faces.py
@@ -1,0 +1,299 @@
+"""InsightFace based face detection and embedding utilities.
+
+Example
+-------
+>>> import numpy as np
+>>> pipeline = InsightFacePipeline(
+...     det_model="scrfd_500m_bnkps.onnx",
+...     rec_model="arcface_r100_v1.onnx",
+...     providers=["CPUExecutionProvider"],
+... )
+>>> frame = np.zeros((640, 640, 3), dtype=np.uint8)
+>>> embeddings = pipeline(frame)  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+
+from ._device import resolve_device_config
+from .detectors import BoundingBox
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    import numpy as np
+
+try:  # pragma: no cover - optional dependency guard
+    import numpy as _np
+except Exception:  # pragma: no cover - fallback when numpy is missing
+    _np = None
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FacePipelineError(RuntimeError):
+    """Raised when the InsightFace pipeline fails."""
+
+
+@dataclass
+class FaceEmbedding:
+    """A face detection enriched with an embedding vector."""
+
+    bbox: BoundingBox
+    keypoints: List[Tuple[float, float]]
+    score: float
+    embedding: Optional[List[float]] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+def _ensure_numpy() -> Any:
+    if _np is None:
+        raise FacePipelineError("numpy is required for face processing")
+    return _np
+
+
+def _as_image(image: Any) -> Any:
+    np = _ensure_numpy()
+    array = np.asarray(image)
+    if array.ndim not in (2, 3):
+        raise ValueError("InsightFace expects HxW or HxWxC arrays")
+    return array
+
+
+def _resolve_ctx_id(device: Optional[Union[str, int]], config: Mapping[str, Any]) -> int:
+    if isinstance(device, int):
+        return device
+    if isinstance(device, str):
+        lowered = device.lower()
+        if lowered.startswith("cuda"):
+            parts = lowered.split(":", 1)
+            if len(parts) == 2 and parts[1].isdigit():
+                return int(parts[1])
+            return 0
+        if lowered.startswith("gpu") and ":" in lowered:
+            _, index = lowered.split(":", 1)
+            if index.isdigit():
+                return int(index)
+        if lowered.startswith("cpu"):
+            return -1
+    candidate = config.get("ctx_id") or config.get("device") or config.get("gpu")
+    if isinstance(candidate, int):
+        return candidate
+    if isinstance(candidate, str):
+        lowered = candidate.lower()
+        if lowered in {"cpu", "-1"}:
+            return -1
+        if lowered.isdigit():
+            return int(lowered)
+    provider = config.get("provider") or config.get("execution_provider")
+    if isinstance(provider, str) and provider.lower().startswith("cpu"):
+        return -1
+    return -1
+
+
+def _resolve_det_size(config: Mapping[str, Any], default: Tuple[int, int]) -> Tuple[int, int]:
+    size = config.get("det_size") or config.get("image_size") or config.get("size")
+    if isinstance(size, (list, tuple)) and len(size) == 2:
+        return int(size[0]), int(size[1])
+    if isinstance(size, int):
+        return int(size), int(size)
+    if isinstance(size, str) and "x" in size:
+        left, right = size.lower().split("x", 1)
+        if left.isdigit() and right.isdigit():
+            return int(left), int(right)
+    return default
+
+
+def _normalise_providers(config: Mapping[str, Any], providers: Optional[Sequence[str]]) -> Optional[List[str]]:
+    if providers:
+        return [str(p) for p in providers]
+    candidate = config.get("providers") or config.get("provider")
+    if isinstance(candidate, str):
+        return [candidate]
+    if isinstance(candidate, Sequence):
+        return [str(item) for item in candidate]
+    return None
+
+
+class InsightFacePipeline:
+    """Run SCRFD detection followed by ArcFace embedding with retries."""
+
+    def __init__(
+        self,
+        det_model: str,
+        rec_model: str,
+        *,
+        device: Optional[Union[str, int]] = None,
+        device_manager: Optional[Any] = None,
+        providers: Optional[Sequence[str]] = None,
+        model_root: Optional[str] = None,
+        det_threshold: float = 0.5,
+        nms_threshold: float = 0.4,
+        align_size: int = 112,
+        max_attempts: int = 3,
+        timeout: Optional[float] = 10.0,
+    ) -> None:
+        self.det_model = det_model
+        self.rec_model = rec_model
+        general_config = resolve_device_config(device_manager, "insightface")
+        detector_config = resolve_device_config(device_manager, "insightface.detector")
+        merged_config: Dict[str, Any] = {**general_config, **detector_config}
+
+        self.ctx_id = _resolve_ctx_id(device, merged_config)
+        self.det_size = _resolve_det_size(merged_config, (640, 640))
+        self.providers = _normalise_providers(merged_config, providers)
+        self.model_root = model_root
+        self.det_threshold = float(det_threshold)
+        self.nms_threshold = float(nms_threshold)
+        self.align_size = int(align_size)
+        self.max_attempts = max(1, int(max_attempts))
+        self.timeout = timeout
+
+        self._detector = None
+        self._embedder = None
+        self._model_lock = threading.Lock()
+
+    def _load_models(self) -> Tuple[Any, Any]:
+        try:
+            from insightface.model_zoo import get_model  # type: ignore
+            from insightface.utils import face_align  # noqa: F401  # ensure dependency is present
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise FacePipelineError("insightface is required for face embeddings") from exc
+
+        kwargs = {"download": False}
+        if self.model_root is not None:
+            kwargs["root"] = self.model_root
+        if self.providers is not None:
+            kwargs["providers"] = self.providers
+
+        try:
+            detector = get_model(self.det_model, **kwargs)
+            embedder = get_model(self.rec_model, **kwargs)
+        except Exception as exc:
+            raise FacePipelineError("Unable to load InsightFace models") from exc
+
+        try:
+            detector.prepare(ctx_id=self.ctx_id, det_thresh=self.det_threshold, nms_thresh=self.nms_threshold)
+        except Exception as exc:
+            raise FacePipelineError("Failed to prepare SCRFD detector") from exc
+
+        try:
+            embedder.prepare(ctx_id=self.ctx_id)
+        except Exception as exc:
+            raise FacePipelineError("Failed to prepare ArcFace embedder") from exc
+
+        return detector, embedder
+
+    def _ensure_models(self) -> Tuple[Any, Any]:
+        if self._detector is not None and self._embedder is not None:
+            return self._detector, self._embedder
+
+        with self._model_lock:
+            if self._detector is None or self._embedder is None:
+                self._detector, self._embedder = self._load_models()
+        return self._detector, self._embedder
+
+    @staticmethod
+    def _convert_keypoints(points: Any) -> List[Tuple[float, float]]:
+        np = _ensure_numpy()
+        array = np.asarray(points, dtype=float)
+        if array.ndim == 1:
+            array = array.reshape(-1, 2)
+        return [(float(x), float(y)) for x, y in array]
+
+    @staticmethod
+    def _compute_embedding(embedder: Any, aligned_face: Any) -> List[float]:
+        vector = embedder.get(aligned_face)
+        if hasattr(vector, "tolist"):
+            return [float(v) for v in vector.tolist()]
+        if isinstance(vector, Iterable):
+            return [float(v) for v in vector]
+        return [float(vector)]
+
+    def _align_face(self, image: Any, keypoints: Any) -> Any:
+        np = _ensure_numpy()
+        try:
+            from insightface.utils import face_align  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise FacePipelineError("insightface.utils.face_align is required") from exc
+        return face_align.norm_crop(image, keypoints, image_size=self.align_size)
+
+    def _infer_once(self, image: Any, max_faces: Optional[int], with_embeddings: bool) -> List[FaceEmbedding]:
+        detector, embedder = self._ensure_models()
+        max_num = 0 if max_faces is None else int(max_faces)
+        try:
+            bboxes, keypoints = detector.detect(image, max_num=max_num)
+        except Exception as exc:
+            raise FacePipelineError("SCRFD detection failed") from exc
+
+        np = _ensure_numpy()
+        bboxes_array = np.asarray(bboxes) if bboxes is not None else np.zeros((0, 5))
+        keypoints_array = np.asarray(keypoints) if keypoints is not None else np.zeros((0, 5, 2))
+
+        results: List[FaceEmbedding] = []
+        for idx in range(len(bboxes_array)):
+            bbox_values = bboxes_array[idx]
+            score = float(bbox_values[4]) if bbox_values.shape[0] >= 5 else 0.0
+            bbox = BoundingBox(*[float(v) for v in bbox_values[:4]])
+            kps = keypoints_array[idx] if idx < len(keypoints_array) else None
+            keypoint_list = self._convert_keypoints(kps) if kps is not None else []
+
+            embedding: Optional[List[float]] = None
+            if with_embeddings and kps is not None:
+                aligned = self._align_face(image, kps)
+                embedding = self._compute_embedding(embedder, aligned)
+
+            results.append(
+                FaceEmbedding(
+                    bbox=bbox,
+                    keypoints=keypoint_list,
+                    score=score,
+                    embedding=embedding,
+                )
+            )
+        return results
+
+    def analyze(
+        self,
+        image: Any,
+        *,
+        max_faces: Optional[int] = None,
+        with_embeddings: bool = True,
+    ) -> List[FaceEmbedding]:
+        """Detect faces and optionally compute embeddings with retry safety."""
+
+        frame = _as_image(image)
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        attempts = 0
+        last_error: Optional[Exception] = None
+
+        while attempts < self.max_attempts:
+            attempts += 1
+            try:
+                return self._infer_once(frame, max_faces=max_faces, with_embeddings=with_embeddings)
+            except Exception as exc:  # pragma: no cover - depends on runtime errors
+                last_error = exc
+                LOGGER.debug("InsightFace inference failed (attempt %s/%s)", attempts, self.max_attempts, exc_info=True)
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
+                if attempts >= self.max_attempts:
+                    break
+                time.sleep(min(0.5 * attempts, 1.5))
+
+        raise FacePipelineError("InsightFace pipeline failed") from last_error
+
+    def __call__(
+        self,
+        image: Any,
+        *,
+        max_faces: Optional[int] = None,
+        with_embeddings: bool = True,
+    ) -> List[FaceEmbedding]:
+        return self.analyze(image, max_faces=max_faces, with_embeddings=with_embeddings)
+
+
+__all__ = ["FaceEmbedding", "FacePipelineError", "InsightFacePipeline"]

--- a/packages/vision/scenes.py
+++ b/packages/vision/scenes.py
@@ -1,0 +1,142 @@
+"""Scene segmentation utilities powered by PySceneDetect.
+
+Example
+-------
+>>> detector = SceneCutDetector()
+>>> cuts = detector.detect("sample.mp4")  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
+
+from ._device import resolve_device_config
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SceneDetectionError(RuntimeError):
+    """Raised when scene detection fails."""
+
+
+@dataclass
+class SceneCut:
+    """Simple representation of a scene interval."""
+
+    start_seconds: float
+    end_seconds: float
+    start_frame: Optional[int] = None
+    end_frame: Optional[int] = None
+
+    @property
+    def duration(self) -> float:
+        """Return the scene duration in seconds."""
+
+        return max(0.0, float(self.end_seconds) - float(self.start_seconds))
+
+    def as_tuple(self) -> Tuple[float, float]:
+        """Return ``(start_seconds, end_seconds)`` for convenience."""
+
+        return float(self.start_seconds), float(self.end_seconds)
+
+
+class SceneCutDetector:
+    """Detect hard cuts in a video using PySceneDetect."""
+
+    def __init__(
+        self,
+        *,
+        backend: str = "content",
+        threshold: float = 27.0,
+        min_scene_len: int = 15,
+        device_manager: Optional[Any] = None,
+        video_manager_options: Optional[Mapping[str, Any]] = None,
+        max_attempts: int = 3,
+        timeout: Optional[float] = 30.0,
+    ) -> None:
+        config = resolve_device_config(device_manager, "scenedetect")
+        self.backend = str(config.get("backend", backend))
+        self.threshold = float(config.get("threshold", threshold))
+        self.min_scene_len = int(config.get("min_scene_len", min_scene_len))
+        self.frame_skip = int(config.get("frame_skip", 0))
+        self.downscale = int(config.get("downscale", config.get("downscale_factor", 1)))
+        self.video_manager_options = dict(video_manager_options or {})
+        if self.downscale > 1 and "downscale_factor" not in self.video_manager_options:
+            self.video_manager_options["downscale_factor"] = self.downscale
+
+        self.max_attempts = max(1, int(max_attempts))
+        self.timeout = timeout
+
+    def _make_detector(self) -> Any:
+        try:
+            from scenedetect.detectors import ContentDetector, ThresholdDetector
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise SceneDetectionError("PySceneDetect detectors are unavailable") from exc
+
+        backend = self.backend.lower()
+        if backend == "threshold":
+            return ThresholdDetector(threshold=self.threshold, min_scene_len=self.min_scene_len)
+        return ContentDetector(threshold=self.threshold, min_scene_len=self.min_scene_len)
+
+    @staticmethod
+    def _convert_scene(scene: Sequence[Any]) -> SceneCut:
+        start, end = scene
+        start_seconds = float(getattr(start, "get_seconds", lambda: start)())
+        end_seconds = float(getattr(end, "get_seconds", lambda: end)())
+        start_frame = getattr(start, "get_frames", lambda: None)()
+        end_frame = getattr(end, "get_frames", lambda: None)()
+        return SceneCut(
+            start_seconds=start_seconds,
+            end_seconds=end_seconds,
+            start_frame=start_frame,
+            end_frame=end_frame,
+        )
+
+    def detect(self, video: Union[str, Path], *, frame_skip: Optional[int] = None) -> List[SceneCut]:
+        """Detect scenes in ``video`` with retries and timeout."""
+
+        video_path = str(video)
+        skip = self.frame_skip if frame_skip is None else int(frame_skip)
+        options = dict(self.video_manager_options)
+
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        attempts = 0
+        last_error: Optional[Exception] = None
+
+        while attempts < self.max_attempts:
+            attempts += 1
+            try:
+                from scenedetect import SceneManager, open_video
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise SceneDetectionError("PySceneDetect is required") from exc
+
+            try:
+                scene_manager = SceneManager()
+                scene_manager.add_detector(self._make_detector())
+                video_manager = open_video(video_path, **options)
+                try:
+                    scene_manager.detect_scenes(video_manager, frame_skip=skip)
+                finally:
+                    video_manager.release()
+                scenes = scene_manager.get_scene_list()
+                return [self._convert_scene(scene) for scene in scenes]
+            except Exception as exc:  # pragma: no cover - depends on runtime errors
+                last_error = exc
+                LOGGER.debug("Scene detection failed (attempt %s/%s)", attempts, self.max_attempts, exc_info=True)
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
+                if attempts >= self.max_attempts:
+                    break
+                time.sleep(min(0.5 * attempts, 1.5))
+
+        raise SceneDetectionError("Failed to detect scenes") from last_error
+
+    def __call__(self, video: Union[str, Path], *, frame_skip: Optional[int] = None) -> List[SceneCut]:
+        return self.detect(video, frame_skip=frame_skip)
+
+
+__all__ = ["SceneCut", "SceneCutDetector", "SceneDetectionError"]


### PR DESCRIPTION
## Summary
- add a YOLOv8 detector wrapper that honours device manager tuning and retries
- introduce an InsightFace SCRFD+ArcFace face pipeline with alignment utilities
- wire up PySceneDetect-based scene segmentation helpers and shared device config tooling

## Testing
- python -m compileall packages/vision

------
https://chatgpt.com/codex/tasks/task_e_68cc930512b883278408b5183b0b1e8e