### PR TITLE
Add FAISS index persistence and SQLite metadata store

### DIFF
--- a/sentinel-stack/requirements.txt
+++ b/sentinel-stack/requirements.txt
@@ -1,2 +1,3 @@
 PyQt6>=6.4
 pytest>=7.0
+numpy>=1.23

--- a/sentinel-stack/src/core/app.py
+++ b/sentinel-stack/src/core/app.py
@@ -1,10 +1,59 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
-from PyQt6.QtWidgets import QApplication, QMainWindow, QTabWidget
+if TYPE_CHECKING:  # pragma: no cover - for static typing only
+    from PyQt6.QtWidgets import QApplication, QMainWindow, QTabWidget
+else:  # pragma: no cover - executed during runtime
+    if os.environ.get("RUNNING_TESTS") == "1":
+        try:
+            from PyQt6.QtWidgets import QApplication, QMainWindow, QTabWidget  # type: ignore
+        except Exception:
+            class QApplication:  # type: ignore
+                """Minimal QApplication stub for testing."""
+
+                _instance: "QApplication | None" = None
+
+                def __init__(self, *_args, **_kwargs) -> None:
+                    QApplication._instance = self
+
+                @classmethod
+                def instance(cls) -> "QApplication | None":
+                    return cls._instance
+
+                def exec(self) -> None:
+                    return None
+
+            class QMainWindow:  # type: ignore
+                def __init__(self, *_args, **_kwargs) -> None:
+                    self._central_widget = None
+
+                def setWindowTitle(self, *_args, **_kwargs) -> None:
+                    return None
+
+                def resize(self, *_args, **_kwargs) -> None:
+                    return None
+
+                def setCentralWidget(self, widget) -> None:  # type: ignore[override]
+                    self._central_widget = widget
+
+                def show(self) -> None:  # pragma: no cover - trivial
+                    return None
+
+                def closeEvent(self, _event) -> None:  # pragma: no cover - trivial
+                    return None
+
+            class QTabWidget:  # type: ignore
+                def __init__(self) -> None:
+                    self._tabs: list = []
+
+                def addTab(self, widget, name: str) -> None:
+                    self._tabs.append((widget, name))
+    else:  # pragma: no cover - requires PyQt runtime
+        from PyQt6.QtWidgets import QApplication, QMainWindow, QTabWidget
 
 from .interfaces import PluginInterface
 from .plugin_loader import load_plugins

--- a/sentinel-stack/src/core/interfaces.py
+++ b/sentinel-stack/src/core/interfaces.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
-from PyQt6.QtWidgets import QWidget
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QWidget
+else:  # pragma: no cover - exercised indirectly via tests
+    if os.environ.get("RUNNING_TESTS") == "1":
+        try:
+            from PyQt6.QtWidgets import QWidget  # type: ignore
+        except Exception:  # pragma: no cover - executed when Qt libraries are unavailable
+            class QWidget:  # type: ignore
+                """Fallback QWidget stub used for headless testing."""
+
+                pass
+    else:  # pragma: no cover - requires PyQt runtime
+        from PyQt6.QtWidgets import QWidget
 
 
 class PluginInterface(ABC):

--- a/sentinel-stack/src/indexer/__init__.py
+++ b/sentinel-stack/src/indexer/__init__.py
@@ -1,0 +1,11 @@
+"""Indexer utilities for managing embeddings and metadata."""
+
+from .faiss_index import FaissIndex, FaissIndexError
+from .store import MetadataStore, main as store_cli_main
+
+__all__ = [
+    "FaissIndex",
+    "FaissIndexError",
+    "MetadataStore",
+    "store_cli_main",
+]

--- a/sentinel-stack/src/indexer/faiss_index.py
+++ b/sentinel-stack/src/indexer/faiss_index.py
@@ -1,0 +1,356 @@
+"""FAISS index management with optional numpy fallback."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence, Tuple, Union
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+try:  # pragma: no cover - import guarded for environments without faiss
+    import faiss  # type: ignore
+except ImportError:  # pragma: no cover - handled gracefully at runtime
+    faiss = None  # type: ignore
+
+DistanceMetric = Union[str, "Metric"]
+
+
+class FaissIndexError(RuntimeError):
+    """Raised when FAISS specific operations cannot be completed."""
+
+
+@dataclass(frozen=True)
+class Metric:
+    """Enumeration of supported distance metrics."""
+
+    name: str
+
+    @classmethod
+    def l2(cls) -> "Metric":
+        return cls("l2")
+
+    @classmethod
+    def inner_product(cls) -> "Metric":
+        return cls("ip")
+
+    @classmethod
+    def cosine(cls) -> "Metric":
+        return cls("cosine")
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.name
+
+
+_SUPPORTED_METRICS = {"l2", "ip", "cosine"}
+
+
+def _normalise_metric(metric: DistanceMetric) -> str:
+    name = str(metric).lower()
+    if name not in _SUPPORTED_METRICS:
+        raise ValueError(f"Unsupported metric '{metric}'. Supported metrics: {sorted(_SUPPORTED_METRICS)}")
+    return name
+
+
+class FaissIndex:
+    """Wrapper around a FAISS index with persistence helpers.
+
+    The class provides a numpy fallback to keep tests deterministic when the
+    optional ``faiss`` dependency is not installed. Only a subset of FAISS
+    functionality is exposed: adding embeddings, k-NN search, and saving/loading
+    indices from disk.
+    """
+
+    def __init__(
+        self,
+        dimension: int,
+        metric: DistanceMetric = "l2",
+        use_faiss: bool | None = None,
+    ) -> None:
+        if dimension <= 0:
+            raise ValueError("dimension must be a positive integer")
+
+        metric_name = _normalise_metric(metric)
+
+        if use_faiss is None:
+            use_faiss = faiss is not None
+
+        if use_faiss and faiss is None:
+            raise FaissIndexError("The 'faiss' package is not installed. Install faiss or set use_faiss=False.")
+
+        self.dimension = dimension
+        self.metric = metric_name
+        self._use_faiss = bool(use_faiss)
+        self._index = self._create_faiss_index() if self._use_faiss else None
+        self._vectors: NDArray[np.float32] = np.empty((0, dimension), dtype=np.float32)
+        self._ids: List[int] = []
+        self._next_id: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def use_faiss(self) -> bool:
+        """Return whether the instance uses a real FAISS backend."""
+
+        return self._use_faiss
+
+    def __len__(self) -> int:
+        return len(self._ids)
+
+    def add(self, embeddings: ArrayLike, ids: Sequence[int] | None = None) -> List[int]:
+        """Add embeddings to the index and return the assigned identifiers."""
+
+        vectors = self._ensure_matrix(embeddings)
+        if vectors.size == 0:
+            return []
+
+        if self.metric == "cosine":
+            vectors = self._normalise(vectors)
+
+        assigned_ids = self._prepare_ids(vectors.shape[0], ids)
+
+        if self._use_faiss:
+            assert self._index is not None  # for type checkers
+            self._index.add_with_ids(vectors, np.asarray(assigned_ids, dtype=np.int64))
+        else:
+            self._vectors = self._stack_vectors(self._vectors, vectors)
+
+        self._ids.extend(assigned_ids)
+        self._next_id = max(self._next_id, max(assigned_ids) + 1)
+        return assigned_ids
+
+    def search(self, queries: ArrayLike, k: int) -> Tuple[NDArray[np.float32], NDArray[np.int64]]:
+        """Run a k-NN search against the index."""
+
+        if k <= 0:
+            raise ValueError("k must be a positive integer")
+
+        query_matrix = self._ensure_matrix(queries)
+        fill_value = np.inf if self.metric == "l2" else -np.inf
+
+        if query_matrix.size == 0:
+            distances = np.empty((0, k), dtype=np.float32)
+            ids = np.empty((0, k), dtype=np.int64)
+            return distances, ids
+
+        if self.metric == "cosine":
+            query_matrix = self._normalise(query_matrix)
+
+        if self._use_faiss:
+            assert self._index is not None
+            distances, ids = self._index.search(query_matrix, k)
+            return distances.astype(np.float32), ids.astype(np.int64)
+
+        if len(self._ids) == 0:
+            distances = np.full((query_matrix.shape[0], k), fill_value, dtype=np.float32)
+            ids = np.full((query_matrix.shape[0], k), -1, dtype=np.int64)
+            return distances, ids
+
+        return self._search_numpy(query_matrix, k)
+
+    def reset(self) -> None:
+        """Remove all embeddings from the index."""
+
+        if self._use_faiss:
+            assert self._index is not None
+            self._index.reset()
+        self._vectors = np.empty((0, self.dimension), dtype=np.float32)
+        self._ids.clear()
+        self._next_id = 0
+
+    def save(self, path: Union[str, Path]) -> None:
+        """Persist the index to disk.
+
+        Parameters
+        ----------
+        path:
+            File path used as the base name for the persisted artifacts. Two
+            sidecar files are created alongside the index file: ``*.meta.json``
+            storing metadata and ``*.ids.json`` storing the identifier mapping.
+        """
+
+        base_path = Path(path)
+        base_path.parent.mkdir(parents=True, exist_ok=True)
+
+        metadata = {
+            "backend": "faiss" if self._use_faiss else "numpy",
+            "dimension": self.dimension,
+            "metric": self.metric,
+            "count": len(self._ids),
+            "next_id": self._next_id,
+        }
+
+        ids_path = self._ids_path(base_path)
+
+        if self._use_faiss:
+            if faiss is None:
+                raise FaissIndexError("Cannot save FAISS index: faiss module unavailable at runtime.")
+            assert self._index is not None
+            faiss.write_index(self._index, str(base_path))
+            metadata["index_file"] = base_path.name
+        else:
+            data_path = self._data_path(base_path)
+            np.savez_compressed(data_path, vectors=self._vectors.astype(np.float32))
+            metadata["index_file"] = data_path.name
+
+        metadata["ids_file"] = ids_path.name
+        self._write_json(ids_path, self._ids)
+        self._write_json(self._metadata_path(base_path), metadata)
+
+    @classmethod
+    def load(cls, path: Union[str, Path], prefer_faiss: bool | None = None) -> "FaissIndex":
+        """Load an index from disk."""
+
+        base_path = Path(path)
+        metadata_path = cls._metadata_path(base_path)
+        if not metadata_path.exists():
+            raise FaissIndexError(f"Metadata file '{metadata_path}' does not exist.")
+
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metric = metadata.get("metric", "l2")
+        dimension = int(metadata["dimension"])
+        backend = metadata.get("backend", "faiss")
+        ids_file = metadata_path.parent / metadata.get("ids_file", cls._ids_path(base_path).name)
+        ids = cls._read_ids(ids_file)
+
+        use_faiss = backend == "faiss"
+        if prefer_faiss is not None:
+            use_faiss = prefer_faiss and backend == "faiss"
+
+        if use_faiss and faiss is None:
+            raise FaissIndexError("The saved index requires the 'faiss' package, but it is not installed.")
+
+        index = cls(dimension=dimension, metric=metric, use_faiss=use_faiss)
+        index._ids = ids
+        index._next_id = int(metadata.get("next_id", len(ids)))
+
+        data_file = metadata_path.parent / metadata.get("index_file", base_path.name)
+
+        if use_faiss:
+            if not data_file.exists():
+                raise FaissIndexError(f"FAISS index file '{data_file}' is missing.")
+            assert faiss is not None
+            index._index = faiss.read_index(str(data_file))
+        else:
+            if not data_file.exists():
+                raise FaissIndexError(f"Vector store file '{data_file}' is missing.")
+            with np.load(data_file) as data:
+                vectors = data["vectors"].astype(np.float32)
+            if vectors.ndim == 1:
+                vectors = np.expand_dims(vectors, axis=0)
+            index._vectors = vectors
+
+        return index
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _create_faiss_index(self):
+        if faiss is None:
+            raise FaissIndexError("FAISS backend requested but the 'faiss' package is not available.")
+
+        if self.metric == "l2":
+            base = faiss.IndexFlatL2(self.dimension)
+        else:
+            base = faiss.IndexFlatIP(self.dimension)
+        return faiss.IndexIDMap(base)
+
+    def _ensure_matrix(self, data: ArrayLike) -> NDArray[np.float32]:
+        array = np.asarray(data, dtype=np.float32)
+        if array.ndim == 1:
+            array = np.expand_dims(array, axis=0)
+        if array.ndim != 2:
+            raise ValueError("Embeddings must be a 1D or 2D array")
+        if array.shape[1] != self.dimension:
+            raise ValueError(f"Expected embeddings with dimension {self.dimension}, received {array.shape[1]}")
+        return array
+
+    def _prepare_ids(self, count: int, ids: Sequence[int] | None) -> List[int]:
+        if ids is None:
+            assigned = list(range(self._next_id, self._next_id + count))
+        else:
+            if len(ids) != count:
+                raise ValueError("The number of ids must match the number of embeddings")
+            assigned = [int(i) for i in ids]
+
+        existing_ids = set(self._ids)
+        if existing_ids.intersection(assigned):
+            raise ValueError("Duplicate identifiers detected")
+        return assigned
+
+    def _normalise(self, matrix: NDArray[np.float32]) -> NDArray[np.float32]:
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return matrix / norms
+
+    def _stack_vectors(
+        self,
+        existing: NDArray[np.float32],
+        new_vectors: NDArray[np.float32],
+    ) -> NDArray[np.float32]:
+        if existing.size == 0:
+            return new_vectors.copy()
+        return np.vstack([existing, new_vectors])
+
+    def _search_numpy(self, query_matrix: NDArray[np.float32], k: int) -> Tuple[NDArray[np.float32], NDArray[np.int64]]:
+        vectors = self._vectors
+        ids_array = np.asarray(self._ids, dtype=np.int64)
+        top_k = min(k, len(self._ids))
+
+        fill_value = np.inf if self.metric == "l2" else -np.inf
+        distances = np.full((query_matrix.shape[0], k), fill_value, dtype=np.float32)
+        id_results = np.full((query_matrix.shape[0], k), -1, dtype=np.int64)
+
+        if top_k == 0:
+            return distances, id_results
+
+        if self.metric == "l2":
+            diff = query_matrix[:, None, :] - vectors[None, :, :]
+            matrix = np.sum(diff ** 2, axis=2)
+            order = np.argsort(matrix, axis=1)
+            sorted_distances = np.take_along_axis(matrix, order, axis=1)
+        else:
+            matrix = query_matrix @ vectors.T
+            order = np.argsort(-matrix, axis=1)
+            sorted_distances = np.take_along_axis(matrix, order, axis=1)
+
+        order = order[:, :top_k]
+        sorted_distances = sorted_distances[:, :top_k]
+
+        selected_ids = np.take(ids_array, order)
+        distances[:, :top_k] = sorted_distances
+        id_results[:, :top_k] = selected_ids
+        return distances, id_results
+
+    @staticmethod
+    def _metadata_path(base_path: Path) -> Path:
+        if base_path.suffix:
+            return base_path.with_suffix(base_path.suffix + ".meta.json")
+        return base_path.with_name(base_path.name + ".meta.json")
+
+    @staticmethod
+    def _ids_path(base_path: Path) -> Path:
+        if base_path.suffix:
+            return base_path.with_suffix(base_path.suffix + ".ids.json")
+        return base_path.with_name(base_path.name + ".ids.json")
+
+    @staticmethod
+    def _data_path(base_path: Path) -> Path:
+        if base_path.suffix:
+            return base_path.with_suffix(base_path.suffix + ".npz")
+        return base_path.with_suffix(".npz")
+
+    @staticmethod
+    def _write_json(path: Path, data: object) -> None:
+        content = json.dumps(data, indent=2, sort_keys=True)
+        path.write_text(content, encoding="utf-8")
+
+    @staticmethod
+    def _read_ids(path: Path) -> List[int]:
+        if not path.exists():
+            return []
+        ids = json.loads(path.read_text(encoding="utf-8"))
+        return [int(i) for i in ids]

--- a/sentinel-stack/src/indexer/store.py
+++ b/sentinel-stack/src/indexer/store.py
@@ -1,0 +1,182 @@
+"""SQLite metadata store for SentinelStack."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+SCHEMA_STATEMENTS: Sequence[str] = (
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+    """
+    CREATE TABLE IF NOT EXISTS media (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        path TEXT NOT NULL UNIQUE,
+        type TEXT NOT NULL,
+        checksum TEXT,
+        duration REAL,
+        frame_rate REAL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        metadata TEXT
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS embeddings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        media_id INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        model TEXT,
+        dim INTEGER NOT NULL,
+        vector BLOB NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        metadata TEXT,
+        FOREIGN KEY(media_id) REFERENCES media(id) ON DELETE CASCADE
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS faces (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        media_id INTEGER NOT NULL,
+        embedding_id INTEGER,
+        time_offset REAL,
+        bbox TEXT,
+        landmarks TEXT,
+        attributes TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(media_id) REFERENCES media(id) ON DELETE CASCADE,
+        FOREIGN KEY(embedding_id) REFERENCES embeddings(id) ON DELETE SET NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS scenes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        media_id INTEGER NOT NULL,
+        start_time REAL NOT NULL,
+        end_time REAL,
+        label TEXT,
+        confidence REAL,
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(media_id) REFERENCES media(id) ON DELETE CASCADE
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS transcripts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        media_id INTEGER NOT NULL,
+        start_time REAL,
+        end_time REAL,
+        speaker TEXT,
+        text TEXT NOT NULL,
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(media_id) REFERENCES media(id) ON DELETE CASCADE
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS anomalies (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        media_id INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        score REAL,
+        severity REAL,
+        details TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(media_id) REFERENCES media(id) ON DELETE CASCADE
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_embeddings_media_type ON embeddings(media_id, type);",
+    "CREATE INDEX IF NOT EXISTS idx_faces_media_time ON faces(media_id, time_offset);",
+    "CREATE INDEX IF NOT EXISTS idx_scenes_media_start ON scenes(media_id, start_time);",
+    "CREATE INDEX IF NOT EXISTS idx_transcripts_media_start ON transcripts(media_id, start_time);",
+    "CREATE INDEX IF NOT EXISTS idx_anomalies_media_kind ON anomalies(media_id, kind);",
+)
+
+
+@dataclass
+class MetadataStore:
+    """Utility wrapper around an SQLite database."""
+
+    db_path: Path | str
+    timeout: float = 30.0
+    read_only: bool = False
+
+    def __post_init__(self) -> None:
+        self._path = Path(self.db_path) if self.db_path != ":memory:" else None
+        if not self.read_only and self._path is not None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        if self.read_only:
+            if self._path is None:
+                uri = f"file:{self.db_path}?mode=ro"
+            else:
+                uri = f"file:{self._path.as_posix()}?mode=ro"
+            self._connection = sqlite3.connect(uri, uri=True, timeout=self.timeout, detect_types=sqlite3.PARSE_DECLTYPES)
+        else:
+            target = ":memory:" if self._path is None else str(self._path)
+            self._connection = sqlite3.connect(target, timeout=self.timeout, detect_types=sqlite3.PARSE_DECLTYPES)
+
+        self._connection.execute("PRAGMA foreign_keys = ON;")
+        self._connection.row_factory = sqlite3.Row
+
+    # ------------------------------------------------------------------
+    # Context manager helpers
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "MetadataStore":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._connection
+
+    def migrate(self) -> None:
+        """Initialise database schema if tables do not exist."""
+
+        with self._connection:
+            for statement in SCHEMA_STATEMENTS:
+                self._connection.execute(statement)
+
+    def table_names(self) -> List[str]:
+        cursor = self._connection.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        return [row[0] for row in cursor.fetchall()]
+
+    def close(self) -> None:
+        self._connection.close()
+
+
+# ----------------------------------------------------------------------
+# Command line interface
+# ----------------------------------------------------------------------
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Manage the SentinelStack metadata store")
+    parser.add_argument("command", choices=["init"], help="Initialise the metadata store if needed")
+    parser.add_argument("db_path", type=Path, help="Path to the SQLite database file")
+    parser.add_argument("--force", action="store_true", help="Run migrations even if the database exists")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    is_new = not args.db_path.exists()
+
+    if args.command == "init":
+        with MetadataStore(args.db_path) as store:
+            if is_new or args.force:
+                store.migrate()
+                message = f"Initialised metadata store at {args.db_path}"
+            else:
+                store.migrate()
+                message = f"Metadata store already present at {args.db_path}"
+        print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentinel-stack/src/plugins/sensor_plugin/plugin.py
+++ b/sentinel-stack/src/plugins/sensor_plugin/plugin.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 os.environ.setdefault("XDG_RUNTIME_DIR", "/tmp")
 
-from PyQt6.QtWidgets import QApplication, QLabel
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QApplication, QLabel
+else:  # pragma: no cover - executed in runtime environments
+    if os.environ.get("RUNNING_TESTS") == "1":
+        try:
+            from PyQt6.QtWidgets import QApplication, QLabel  # type: ignore
+        except Exception:
+            class QApplication:  # type: ignore
+                """Minimal QApplication stub for tests."""
+
+                _instance: "QApplication | None" = None
+
+                def __init__(self, *_args, **_kwargs) -> None:
+                    QApplication._instance = self
+
+                @classmethod
+                def instance(cls) -> "QApplication | None":
+                    return cls._instance
+
+                def exec(self) -> None:  # pragma: no cover - trivial
+                    return None
+
+            class QLabel:  # type: ignore
+                def __init__(self, text: str = "") -> None:
+                    self._text = text
+
+                def setText(self, text: str) -> None:
+                    self._text = text
+    else:  # pragma: no cover - requires PyQt runtime
+        from PyQt6.QtWidgets import QApplication, QLabel
 
 from core.interfaces import PluginInterface
 

--- a/sentinel-stack/tests/indexer/test_faiss_index.py
+++ b/sentinel-stack/tests/indexer/test_faiss_index.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from indexer.faiss_index import FaissIndex, FaissIndexError
+
+
+@pytest.mark.parametrize("metric", ["l2", "cosine"])
+def test_add_search_and_persistence(metric: str, tmp_path: Path) -> None:
+    index = FaissIndex(dimension=4, metric=metric, use_faiss=False)
+
+    vectors = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 1.0],
+            [2.0, 2.0, 2.0, 2.0],
+        ],
+        dtype=np.float32,
+    )
+
+    assigned = index.add(vectors)
+    assert assigned == [0, 1, 2]
+    assert len(index) == 3
+
+    distances, ids = index.search(np.array([vectors[0]]), k=2)
+    assert distances.shape == (1, 2)
+    assert ids.shape == (1, 2)
+    assert ids[0, 0] == 0
+
+    output_path = tmp_path / "embeddings.index"
+    index.save(output_path)
+
+    metadata_path = output_path.with_suffix(output_path.suffix + ".meta.json")
+    ids_path = output_path.with_suffix(output_path.suffix + ".ids.json")
+    assert metadata_path.exists()
+    assert ids_path.exists()
+
+    with metadata_path.open("r", encoding="utf-8") as handle:
+        metadata = json.load(handle)
+    data_file = metadata_path.parent / metadata["index_file"]
+    assert data_file.exists()
+
+    reloaded = FaissIndex.load(output_path, prefer_faiss=False)
+    assert len(reloaded) == 3
+
+    distances_reload, ids_reload = reloaded.search(np.array([[1.0, 1.0, 1.0, 1.0]], dtype=np.float32), k=3)
+    assert ids_reload[0, 0] in assigned
+    assert np.all(np.isfinite(distances_reload))
+
+
+def test_duplicate_ids_raise(tmp_path: Path) -> None:
+    index = FaissIndex(dimension=2, use_faiss=False)
+    index.add([[0.0, 0.0]], ids=[5])
+
+    with pytest.raises(ValueError):
+        index.add([[1.0, 1.0]], ids=[5])
+
+
+def test_loading_missing_files(tmp_path: Path) -> None:
+    path = tmp_path / "missing.index"
+    with pytest.raises(FaissIndexError):
+        FaissIndex.load(path, prefer_faiss=False)

--- a/sentinel-stack/tests/indexer/test_store.py
+++ b/sentinel-stack/tests/indexer/test_store.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from indexer.store import MetadataStore, main
+
+
+def test_migrate_creates_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "metadata.db"
+    assert not db_path.exists()
+
+    result = main(["init", str(db_path)])
+    assert result == 0
+    assert db_path.exists()
+
+    with MetadataStore(db_path) as store:
+        tables = set(store.table_names())
+
+    expected_tables = {"media", "embeddings", "faces", "scenes", "transcripts", "anomalies"}
+    assert expected_tables.issubset(tables)
+
+    # Second migration should be idempotent
+    result_again = main(["init", str(db_path)])
+    assert result_again == 0


### PR DESCRIPTION
## Summary
- add a FAISS-backed embedding index with numpy fallback plus save/load helpers
- introduce a SQLite metadata store with schema migrations and CLI init command
- provide testing fallbacks for PyQt widgets and add unit tests covering the index and store

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc93118b0c8327962752c9ca26c6a1