### PR TITLE
Add guardrails for network, filesystem, privacy, and provenance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Overview
+
+FaceTrace enforces a strict offline-first posture. The current release ships
+with the following guardrails to keep data, models, and pipelines isolated.
+
+## Network Egress
+
+- The Nebula DOM Cartographer inference adapter refuses outbound requests by
+  default. Payloads must carry an explicit `@allow-network` annotation (or set
+  `allowNetwork: true`) before any egress is attempted.
+- Requests that do not opt in raise a blocking error and never invoke `fetch`,
+  ensuring the pipeline stays air-gapped unless an operator authorises a
+  connection.
+
+## File-System Safety
+
+- The Control Room server exposes a hardened `safeJoin` helper that resolves and
+  normalises all file paths inside `/workspace/.nexusforge`.
+- Directory traversal and symlink escapes are rejected before any read/write
+  occurs. Live log streaming re-validates the canonical path on every read so a
+  swapped symlink cannot leak data.
+
+## Privacy Controls
+
+- The UI now visualises detected faces with an explicit privacy banner. When
+  privacy mode is enabled, any face without a whitelist/label is blurred before
+  rendering so unvetted identities never appear in clear text.
+
+## Provenance Tracking
+
+- Project Aura records the SHA-256 hash of the active codebase and configured
+  language model into a SQLite provenance database (`~/.cache/project_aura` by
+  default).
+- Repeated runs update existing rows instead of duplicating them, keeping an
+  auditable trail of the latest versions used in production.
+
+## Reporting Issues
+
+Security vulnerabilities should be reported privately to the maintainers.
+Please include repro steps and any relevant context so fixes can be triaged
+quickly.

--- a/control-room/src/app/page.tsx
+++ b/control-room/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import ProgressBoard from '@/components/ProgressBoard';
 import LiveLog from '@/components/LiveLog';
 import ChecksList from '@/components/ChecksList';
+import FaceGallery from '@/components/FaceGallery';
 
 export default function Page() {
   const [state, setState] = useState<any>({});
@@ -16,6 +17,15 @@ export default function Page() {
   return (
     <main className="space-y-4">
       <ProgressBoard data={state} />
+      <FaceGallery
+        faces={Array.isArray(state.faces) ? state.faces : []}
+        privacyMode={Boolean(
+          state.privacy_mode ?? state.privacyMode ?? state.privacy?.enabled ?? false,
+        )}
+        footer={state.privacy_notice ? (
+          <p className="text-xs text-gray-400">{state.privacy_notice}</p>
+        ) : undefined}
+      />
       <ChecksList checks={checks} />
       <LiveLog />
     </main>

--- a/control-room/src/components/FaceGallery.tsx
+++ b/control-room/src/components/FaceGallery.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react';
+
+import {
+  FaceRecord,
+  findFaceLabel,
+  formatConfidence,
+  isFaceLabelled,
+  resolveFaceImage,
+} from '@/lib/faces';
+
+interface FaceGalleryProps {
+  faces: unknown[];
+  privacyMode: boolean;
+  footer?: ReactNode;
+}
+
+export default function FaceGallery({ faces, privacyMode, footer }: FaceGalleryProps) {
+  const normalisedFaces: FaceRecord[] = Array.isArray(faces)
+    ? faces.filter((face): face is FaceRecord => !!face && typeof face === 'object')
+    : [];
+
+  return (
+    <section className="space-y-3 rounded-lg border border-gray-800 bg-gray-900/60 p-4 shadow">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-white">Face Detections</h2>
+        <span
+          className={`text-xs uppercase tracking-wide ${
+            privacyMode ? 'text-emerald-400' : 'text-gray-400'
+          }`}
+        >
+          Privacy mode {privacyMode ? 'ON' : 'OFF'}
+        </span>
+      </div>
+
+      {normalisedFaces.length === 0 ? (
+        <p className="text-sm text-gray-400">No face detections available yet.</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {normalisedFaces.map((face, index) => {
+            const labelled = isFaceLabelled(face);
+            const shouldBlur = privacyMode && !labelled;
+            const src = resolveFaceImage(face);
+            const label = findFaceLabel(face) ?? `Face ${index + 1}`;
+            const confidenceDisplay = formatConfidence(face.confidence);
+
+            return (
+              <div key={String(face.id ?? index)} className="rounded-lg bg-gray-800 p-2 shadow">
+                <div className="relative overflow-hidden rounded border border-gray-700">
+                  {src ? (
+                    <img
+                      src={src}
+                      alt={label}
+                      className={`h-32 w-full object-cover transition duration-200 ${
+                        shouldBlur ? 'scale-105 filter blur-lg' : ''
+                      }`}
+                    />
+                  ) : (
+                    <div className="flex h-32 w-full items-center justify-center bg-gray-900 text-xs text-gray-500">
+                      No preview
+                    </div>
+                  )}
+                  {shouldBlur && <div className="absolute inset-0 bg-gray-900/40" aria-hidden="true" />}
+                  <div className="absolute left-2 top-2 rounded bg-black/60 px-2 py-0.5 text-[10px] uppercase tracking-wide">
+                    {labelled ? 'Labelled' : 'Unlabelled'}
+                  </div>
+                </div>
+                <div className="mt-2 space-y-1 text-xs text-gray-300">
+                  <div className="text-sm font-medium text-white">{label}</div>
+                  {privacyMode && (
+                    <div className={shouldBlur ? 'text-amber-400' : 'text-emerald-400'}>
+                      {shouldBlur ? 'Blurred for privacy' : 'Visible'}
+                    </div>
+                  )}
+                  {confidenceDisplay && <div className="text-gray-400">Confidence: {confidenceDisplay}</div>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {footer}
+    </section>
+  );
+}

--- a/control-room/src/lib/faces.ts
+++ b/control-room/src/lib/faces.ts
@@ -1,0 +1,136 @@
+export type FaceRecord = {
+  id?: string | number;
+  label?: string | null;
+  labels?: unknown;
+  annotations?: unknown;
+  metadata?: Record<string, unknown> | null;
+  meta?: Record<string, unknown> | null;
+  whitelisted?: boolean;
+  whitelist?: boolean;
+  status?: string;
+  confidence?: number;
+  [key: string]: unknown;
+};
+
+export function coerceStrings(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap(coerceStrings);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[,\s]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function extractMetadata(face: FaceRecord): Record<string, unknown> {
+  const metadata = face.metadata ?? face.meta;
+  return metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>) : {};
+}
+
+export function findFaceLabel(face: FaceRecord): string | undefined {
+  if (typeof face.label === 'string' && face.label.trim()) {
+    return face.label.trim();
+  }
+
+  const metadata = extractMetadata(face);
+  const metadataLabel = metadata.label;
+  if (typeof metadataLabel === 'string' && metadataLabel.trim()) {
+    return metadataLabel.trim();
+  }
+
+  const labelSources = [face.labels, metadata.labels];
+  for (const source of labelSources) {
+    const list = coerceStrings(source);
+    if (list.length > 0) {
+      return list[0];
+    }
+  }
+
+  if (typeof face.id === 'string' && face.id.trim()) {
+    return face.id.trim();
+  }
+
+  return undefined;
+}
+
+function hasAnnotationToken(values: string[], token: string): boolean {
+  return values.some((entry) => entry === token || entry.startsWith(`${token}:`));
+}
+
+export function isFaceLabelled(face: FaceRecord | unknown): boolean {
+  if (!face || typeof face !== 'object') {
+    return false;
+  }
+
+  const record = face as FaceRecord;
+  if (typeof record.label === 'string' && record.label.trim().length > 0) {
+    return true;
+  }
+
+  if (record.whitelisted || record.whitelist) {
+    return true;
+  }
+
+  if (typeof record.status === 'string' && record.status.toLowerCase().includes('label')) {
+    return true;
+  }
+
+  const metadata = extractMetadata(record);
+  if (metadata.whitelisted === true) {
+    return true;
+  }
+  const metadataLabel = metadata.label;
+  if (typeof metadataLabel === 'string' && metadataLabel.trim().length > 0) {
+    return true;
+  }
+
+  const annotationSources = [record.annotations, metadata.annotations];
+  const annotations = annotationSources.flatMap(coerceStrings);
+  if (hasAnnotationToken(annotations, '@labelled')) {
+    return true;
+  }
+  if (annotations.some((entry) => entry.toLowerCase().includes('whitelist'))) {
+    return true;
+  }
+
+  const labelLists = [record.labels, metadata.labels].flatMap(coerceStrings);
+  return labelLists.length > 0;
+}
+
+export function resolveFaceImage(face: FaceRecord): string | undefined {
+  const metadata = extractMetadata(face);
+  const candidates = [
+    face.thumbnail,
+    face.image,
+    (face as Record<string, unknown>)['image_url'],
+    face.imageUrl,
+    face.dataUri,
+    face.dataURI,
+    face.preview,
+    metadata.thumbnail,
+    metadata.preview,
+    metadata.image,
+    metadata.dataUri,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function formatConfidence(value: unknown): string | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const numeric = value;
+  if (numeric >= 0 && numeric <= 1) {
+    return `${(numeric * 100).toFixed(1)}%`;
+  }
+  return `${numeric.toFixed(1)}`;
+}

--- a/control-room/src/lib/fs.ts
+++ b/control-room/src/lib/fs.ts
@@ -1,12 +1,38 @@
 import fs from 'fs';
 import path from 'path';
 
-const BASE = '/workspace/.nexusforge';
+const BASE = path.resolve('/workspace/.nexusforge');
+
+function assertWithinBase(target: string) {
+  const relative = path.relative(BASE, target);
+  if (relative && (relative.startsWith('..') || path.isAbsolute(relative))) {
+    throw new Error('bad path');
+  }
+}
+
+function assertNoSymlinkEscape(target: string) {
+  const relative = path.relative(BASE, target);
+  if (!relative) return;
+  const segments = relative.split(path.sep).filter(Boolean);
+  let current = BASE;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    if (fs.existsSync(current)) {
+      const real = fs.realpathSync(current);
+      assertWithinBase(real);
+    }
+  }
+}
+
+function enforcePathSafety(target: string) {
+  assertWithinBase(target);
+  assertNoSymlinkEscape(target);
+}
 
 export function safeJoin(...segs: string[]) {
-  const p = path.join(BASE, ...segs);
-  if (!p.startsWith(BASE)) throw new Error('bad path');
-  return p;
+  const resolved = path.resolve(BASE, ...segs);
+  enforcePathSafety(resolved);
+  return resolved;
 }
 
 export async function readText(rel: string) {
@@ -55,6 +81,15 @@ export function tailStream(rel: string) {
     start(controller) {
       const send = (line: string) => controller.enqueue(encoder.encode(sseFormat(line)));
       const readNew = () => {
+        try {
+          const real = fs.realpathSync(file);
+          enforcePathSafety(real);
+        } catch (error) {
+          controller.error(error);
+          watcher?.close();
+          clearInterval(timer);
+          return;
+        }
         fs.readFile(file, 'utf8', (err, data) => {
           if (err) return;
           const slice = data.slice(pos);

--- a/control-room/tests/basic.spec.ts
+++ b/control-room/tests/basic.spec.ts
@@ -1,6 +1,32 @@
 import fs from 'fs';
 import path from 'path';
-import { appendCommand, sseFormat } from '../src/lib/fs';
+import { appendCommand, safeJoin, sseFormat } from '../src/lib/fs';
+
+const BASE = path.resolve('/workspace/.nexusforge');
+
+describe('safeJoin', () => {
+  beforeAll(() => {
+    fs.mkdirSync(BASE, { recursive: true });
+  });
+
+  test('rejects directory traversal', () => {
+    expect(() => safeJoin('../etc/passwd')).toThrow('bad path');
+  });
+
+  test('rejects symlink escape', () => {
+    const escapeTarget = path.resolve('/tmp/safejoin-escape');
+    const link = path.join(BASE, 'escape-link');
+    fs.mkdirSync(escapeTarget, { recursive: true });
+    try {
+      if (fs.existsSync(link)) fs.unlinkSync(link);
+      fs.symlinkSync(escapeTarget, link);
+      expect(() => safeJoin('escape-link', 'notes.txt')).toThrow('bad path');
+    } finally {
+      if (fs.existsSync(link)) fs.unlinkSync(link);
+      fs.rmSync(escapeTarget, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('fs helpers', () => {
   test('appendCommand writes json line', async () => {

--- a/control-room/tests/faceGallery.spec.ts
+++ b/control-room/tests/faceGallery.spec.ts
@@ -1,0 +1,19 @@
+import { isFaceLabelled } from '../src/lib/faces';
+
+describe('isFaceLabelled', () => {
+  it('returns false for empty record', () => {
+    expect(isFaceLabelled({})).toBe(false);
+  });
+
+  it('detects explicit label', () => {
+    expect(isFaceLabelled({ label: 'Analyst' })).toBe(true);
+  });
+
+  it('detects whitelisted metadata', () => {
+    expect(isFaceLabelled({ metadata: { whitelisted: true } })).toBe(true);
+  });
+
+  it('detects annotations containing @labelled', () => {
+    expect(isFaceLabelled({ annotations: ['foo', '@labelled'] })).toBe(true);
+  });
+});

--- a/nebula-dom-cartographer/extension/ai/adapter/localhostClient.ts
+++ b/nebula-dom-cartographer/extension/ai/adapter/localhostClient.ts
@@ -1,4 +1,55 @@
+const ALLOW_NETWORK_TOKEN = '@allow-network';
+
+function normaliseAnnotationValue(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap(normaliseAnnotationValue);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[,\s]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === 'object') {
+    return Object.values(value).flatMap(normaliseAnnotationValue);
+  }
+  return [];
+}
+
+function hasAllowNetworkAnnotation(payload: unknown): boolean {
+  if (typeof payload === 'string') {
+    return payload.includes(ALLOW_NETWORK_TOKEN);
+  }
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (record.allowNetwork === true) {
+    return true;
+  }
+
+  const candidates: unknown[] = [
+    record.annotations,
+    record.flags,
+    record.tags,
+    record.directives,
+    record.metadata &&
+      typeof record.metadata === 'object' &&
+      (record.metadata as Record<string, unknown>).annotations,
+  ].filter(Boolean);
+
+  return normaliseAnnotationValue(candidates).includes(ALLOW_NETWORK_TOKEN);
+}
+
 export async function inferLocal(payload: unknown): Promise<unknown> {
+  if (!hasAllowNetworkAnnotation(payload)) {
+    throw new Error(
+      'Network egress blocked: add @allow-network annotation to opt in.',
+    );
+  }
+
   const res = await fetch('http://localhost:8080/infer', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -6,3 +57,5 @@ export async function inferLocal(payload: unknown): Promise<unknown> {
   });
   return res.json();
 }
+
+export { hasAllowNetworkAnnotation };

--- a/nebula-dom-cartographer/tests/unit/localhostClient.test.ts
+++ b/nebula-dom-cartographer/tests/unit/localhostClient.test.ts
@@ -1,0 +1,30 @@
+import { inferLocal, hasAllowNetworkAnnotation } from '../../extension/ai/adapter/localhostClient';
+
+describe('network guard', () => {
+  const json = jest.fn().mockResolvedValue({ ok: true });
+  const fetchMock = jest.fn().mockResolvedValue({ json });
+
+  beforeEach(() => {
+    json.mockClear();
+    fetchMock.mockClear();
+    (globalThis as typeof globalThis & { fetch: typeof fetch }).fetch =
+      fetchMock as unknown as typeof fetch;
+  });
+
+  it('rejects payloads without @allow-network', async () => {
+    await expect(inferLocal({ prompt: 'hello' })).rejects.toThrow('Network egress blocked');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('permits payloads with annotation array', async () => {
+    const result = await inferLocal({ prompt: 'hi', annotations: ['@allow-network'] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('detects annotation in nested metadata', () => {
+    expect(
+      hasAllowNetworkAnnotation({ metadata: { annotations: ['@allow-network'] } }),
+    ).toBe(true);
+  });
+});

--- a/project-aura/aura/app.py
+++ b/project-aura/aura/app.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict
 
 from .core import config as config_module
 from .core.command_bus import CommandBus
+from .core.provenance import snapshot_versions
 from .providers.appaware.win32_foreground import Win32ForegroundProvider
 from .providers.bodytracking.kinect_v2 import KinectV2Provider
 from .providers.gaze.kinect_headpose import KinectHeadPoseProvider
@@ -39,6 +40,7 @@ class AuraApp:
 
     def __init__(self) -> None:
         self.config = config_module.load_config()
+        snapshot_versions(self.config)
         self.bus = CommandBus()
         self.providers: Dict[str, object] = {}
 

--- a/project-aura/aura/core/provenance.py
+++ b/project-aura/aura/core/provenance.py
@@ -1,0 +1,116 @@
+"""Provenance tracking utilities for Project Aura."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from .config import AppConfig
+
+CACHE_DIR = Path.home() / '.cache' / 'project_aura'
+DEFAULT_DB_PATH = CACHE_DIR / 'provenance.sqlite3'
+
+
+def resolve_db_path(override: Optional[Path] = None) -> Path:
+    """Resolve the provenance database path."""
+
+    if override is not None:
+        return override
+    env_path = os.environ.get('AURA_PROVENANCE_DB')
+    if env_path:
+        return Path(env_path).expanduser()
+    return DEFAULT_DB_PATH
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS provenance (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            component TEXT NOT NULL,
+            artifact_type TEXT NOT NULL,
+            version_hash TEXT NOT NULL,
+            metadata TEXT,
+            recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        '''
+    )
+    conn.execute(
+        '''
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_provenance_component_type
+        ON provenance(component, artifact_type)
+        '''
+    )
+
+
+def _compute_directory_hash(root: Path) -> Tuple[str, int]:
+    digest = hashlib.sha256()
+    files = [path for path in sorted(root.rglob('*.py')) if path.is_file()]
+    for path in files:
+        digest.update(path.relative_to(root).as_posix().encode('utf-8'))
+        digest.update(path.read_bytes())
+    return digest.hexdigest(), len(files)
+
+
+def _compute_text_hash(value: str) -> str:
+    return hashlib.sha256(value.encode('utf-8')).hexdigest()
+
+
+def record_provenance(
+    component: str,
+    artifact_type: str,
+    version_hash: str,
+    metadata: Optional[Dict[str, object]] = None,
+    db_path: Optional[Path] = None,
+) -> Path:
+    """Persist a provenance entry, overwriting existing rows for the component."""
+
+    resolved = resolve_db_path(db_path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(metadata, sort_keys=True) if metadata else None
+
+    with sqlite3.connect(resolved) as conn:
+        _ensure_schema(conn)
+        conn.execute(
+            '''
+            INSERT INTO provenance (component, artifact_type, version_hash, metadata)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(component, artifact_type)
+            DO UPDATE SET
+                version_hash=excluded.version_hash,
+                metadata=excluded.metadata,
+                recorded_at=CURRENT_TIMESTAMP
+            ''',
+            (component, artifact_type, version_hash, payload),
+        )
+    return resolved
+
+
+def snapshot_versions(config: AppConfig, db_path: Optional[Path] = None) -> Path:
+    """Record hashes for the core code and active language model."""
+
+    package_root = Path(__file__).resolve().parents[1]
+    code_hash, file_count = _compute_directory_hash(package_root)
+    path = record_provenance(
+        component='aura-core',
+        artifact_type='code',
+        version_hash=code_hash,
+        metadata={'files': file_count, 'root': str(package_root)},
+        db_path=db_path,
+    )
+
+    model_hash = _compute_text_hash(config.llm.model)
+    record_provenance(
+        component='llm',
+        artifact_type='model',
+        version_hash=model_hash,
+        metadata={'model': config.llm.model},
+        db_path=path,
+    )
+    return path
+
+
+__all__ = ['record_provenance', 'resolve_db_path', 'snapshot_versions']

--- a/project-aura/tests/test_provenance.py
+++ b/project-aura/tests/test_provenance.py
@@ -1,0 +1,34 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from aura.core import config as config_module
+from aura.core.provenance import snapshot_versions
+
+
+def test_snapshot_versions_records_hashes(tmp_path: Path) -> None:
+    config = config_module.load_config()
+    db_path = tmp_path / 'provenance.sqlite3'
+    path = snapshot_versions(config, db_path=db_path)
+
+    assert path == db_path
+    assert db_path.exists()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT component, artifact_type, version_hash, metadata FROM provenance'
+        ).fetchall()
+
+    assert {(row[0], row[1]) for row in rows} == {('aura-core', 'code'), ('llm', 'model')}
+
+    for _, _, version_hash, metadata in rows:
+        assert len(version_hash) == 64
+        if metadata:
+            data = json.loads(metadata)
+            assert isinstance(data, dict)
+
+    # Second call updates the same rows without duplicating entries
+    snapshot_versions(config, db_path=db_path)
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute('SELECT COUNT(*) FROM provenance').fetchone()[0]
+    assert count == 2


### PR DESCRIPTION
## Summary
- block network egress unless payloads opt in with `@allow-network` and add coverage
- harden Control Room path handling and surface a privacy-aware face gallery UI
- log code/model provenance hashes via a SQLite registry and document guardrails in SECURITY.md

## Testing
- npm test -- --runInBand (control-room)
- npm test -- --runInBand (nebula-dom-cartographer)
- pytest (project-aura)

------
https://chatgpt.com/codex/tasks/task_e_68cc93323c788327abfb794135dda4e7