### PR TITLE
Refine audio utilities and regenerate EVP test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+__pycache__/
+*.py[cod]

--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package for FaceTrace lane implementations."""

--- a/packages/audio/__init__.py
+++ b/packages/audio/__init__.py
@@ -1,0 +1,30 @@
+"""Audio processing utilities for the AUDIO_PKG lane."""
+from .transcribe import (
+    Segment,
+    TranscriptionResult,
+    transcribe_with_python_whisper,
+    transcribe_with_whisper_cpp,
+)
+from .evp import (
+    EvpAnomalyFlags,
+    EvpFeatureSet,
+    extract_evp_features,
+)
+from .diarize import (
+    EmbeddingSegment,
+    SpeakerEmbeddingResult,
+    compute_speaker_embeddings,
+)
+
+__all__ = [
+    "Segment",
+    "TranscriptionResult",
+    "transcribe_with_python_whisper",
+    "transcribe_with_whisper_cpp",
+    "EvpAnomalyFlags",
+    "EvpFeatureSet",
+    "extract_evp_features",
+    "EmbeddingSegment",
+    "SpeakerEmbeddingResult",
+    "compute_speaker_embeddings",
+]

--- a/packages/audio/diarize.py
+++ b/packages/audio/diarize.py
@@ -1,0 +1,136 @@
+"""Speaker embedding helpers built on top of Resemblyzer."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from .transcribe import DISCLAIMER, PathLike
+
+try:  # pragma: no cover - optional dependency resolution
+    from Resemblyzer import VoiceEncoder, preprocess_wav  # type: ignore[import]
+except ImportError:  # pragma: no cover - handled in _get_encoder
+    VoiceEncoder = None  # type: ignore[assignment]
+    preprocess_wav = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class EmbeddingSegment:
+    """Embedding for an audio slice."""
+
+    start: float
+    end: float
+    embedding: List[float]
+
+
+@dataclass(slots=True)
+class SpeakerEmbeddingResult:
+    """Container for diarisation-friendly embeddings."""
+
+    segments: List[EmbeddingSegment]
+    sample_rate: int
+    disclaimer: str = field(default=DISCLAIMER, init=False)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _get_encoder(encoder: Optional[Any] = None) -> Any:
+    if encoder is not None:
+        return encoder
+    if VoiceEncoder is None:  # pragma: no cover - executed when dependency missing
+        raise RuntimeError(
+            "The 'Resemblyzer' package is required to compute speaker embeddings. "
+            "Install it via 'pip install Resemblyzer'."
+        )
+    return VoiceEncoder()
+
+
+def _preprocess(audio_path: PathLike) -> np.ndarray:
+    if preprocess_wav is None:  # pragma: no cover - executed when dependency missing
+        raise RuntimeError(
+            "Resemblyzer preprocessing helpers are unavailable. Ensure the package is installed."
+        )
+    return preprocess_wav(str(audio_path))
+
+
+def compute_speaker_embeddings(
+    audio_path: PathLike,
+    *,
+    window_size: float = 1.5,
+    hop_size: float = 0.75,
+    encoder: Optional[Any] = None,
+) -> SpeakerEmbeddingResult:
+    """Generate sliding window speaker embeddings using Resemblyzer.
+
+    Parameters
+    ----------
+    audio_path:
+        Audio file analysed for speaker characteristics.
+    window_size:
+        Window size in seconds used for embeddings. Defaults to 1.5 seconds as
+        recommended by the Resemblyzer documentation.
+    hop_size:
+        Hop size between consecutive windows in seconds.
+    encoder:
+        Optional pre-instantiated ``VoiceEncoder`` for dependency injection.
+    """
+
+    wav = _preprocess(audio_path)
+    if wav.size == 0:
+        raise ValueError("Audio file is empty or could not be decoded")
+    sr = 16_000  # Resemblyzer always outputs 16 kHz audio
+    encoder_instance = _get_encoder(encoder)
+
+    window_samples = max(int(window_size * sr), sr // 2)
+    hop_samples = max(int(hop_size * sr), sr // 4)
+
+    segments: List[EmbeddingSegment] = []
+    total_samples = wav.shape[0]
+    if total_samples <= window_samples:
+        embedding = encoder_instance.embed_utterance(wav)
+        segments.append(
+            EmbeddingSegment(
+                start=0.0,
+                end=float(total_samples) / float(sr),
+                embedding=embedding.astype(float).tolist(),
+            )
+        )
+    else:
+        start = 0
+        while start + window_samples <= total_samples:
+            end = start + window_samples
+            chunk = wav[start:end]
+            embedding = encoder_instance.embed_utterance(chunk)
+            segments.append(
+                EmbeddingSegment(
+                    start=start / sr,
+                    end=end / sr,
+                    embedding=embedding.astype(float).tolist(),
+                )
+            )
+            start += hop_samples
+        if segments:
+            last_end = segments[-1].end
+        else:
+            last_end = 0.0
+        if last_end * sr < total_samples:
+            chunk = wav[-window_samples:]
+            embedding = encoder_instance.embed_utterance(chunk)
+            segments.append(
+                EmbeddingSegment(
+                    start=max(total_samples - window_samples, 0) / sr,
+                    end=total_samples / sr,
+                    embedding=embedding.astype(float).tolist(),
+                )
+            )
+
+    metadata = {
+        "window_size": window_size,
+        "hop_size": hop_size,
+        "num_segments": len(segments),
+    }
+    return SpeakerEmbeddingResult(
+        segments=segments,
+        sample_rate=sr,
+        metadata=metadata,
+    )

--- a/packages/audio/evp.py
+++ b/packages/audio/evp.py
@@ -1,0 +1,118 @@
+"""EVP (Electronic Voice Phenomena) feature extraction utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import numpy as np
+
+from .transcribe import DISCLAIMER, PathLike
+
+try:  # pragma: no cover - optional dependency resolution
+    import librosa  # type: ignore[import]
+except ImportError:  # pragma: no cover - handled in _ensure_librosa
+    librosa = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class EvpAnomalyFlags:
+    """Boolean anomaly flags derived from spectral heuristics."""
+
+    is_silent: bool
+    possible_clipping: bool
+    high_noise: bool
+
+
+@dataclass(slots=True)
+class EvpFeatureSet:
+    """Container for EVP-oriented acoustic features."""
+
+    sample_rate: int
+    duration: float
+    features: Dict[str, float]
+    anomaly_flags: EvpAnomalyFlags
+    disclaimer: str = field(default=DISCLAIMER, init=False)
+
+
+def _ensure_librosa() -> None:
+    if librosa is None:  # pragma: no cover - executed when dependency missing
+        raise RuntimeError(
+            "The 'librosa' package is required to extract EVP features. "
+            "Install it via 'pip install librosa'."
+        )
+
+
+def _summarise_feature(values: np.ndarray, prefix: str, output: Dict[str, float]) -> None:
+    output[f"{prefix}_mean"] = float(np.mean(values))
+    output[f"{prefix}_std"] = float(np.std(values))
+    output[f"{prefix}_min"] = float(np.min(values))
+    output[f"{prefix}_max"] = float(np.max(values))
+
+
+def extract_evp_features(
+    audio_path: PathLike,
+    *,
+    target_sr: int = 16_000,
+    top_db: Optional[float] = 60.0,
+) -> EvpFeatureSet:
+    """Extract EVP-friendly spectral descriptors using ``librosa``.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio clip to analyse.
+    target_sr:
+        Sample rate used when loading audio. Defaults to 16 kHz for speech tasks.
+    top_db:
+        When provided, leading/trailing silence is trimmed before analysis using
+        ``librosa.effects.trim``.
+    """
+
+    _ensure_librosa()
+    y, sr = librosa.load(str(audio_path), sr=target_sr, mono=True)
+    if y.size == 0:
+        raise ValueError("Audio file is empty or could not be decoded")
+
+    if top_db is not None:
+        y, _ = librosa.effects.trim(y, top_db=top_db)
+    duration = float(y.size) / float(sr)
+
+    # Normalise amplitude for consistent heuristics.
+    peak = float(np.max(np.abs(y)))
+    if peak > 0:
+        y = y / peak
+
+    features: Dict[str, float] = {}
+    rms = librosa.feature.rms(y=y)
+    zcr = librosa.feature.zero_crossing_rate(y)
+    centroid = librosa.feature.spectral_centroid(y=y, sr=sr)
+    bandwidth = librosa.feature.spectral_bandwidth(y=y, sr=sr)
+    rolloff = librosa.feature.spectral_rolloff(y=y, sr=sr, roll_percent=0.85)
+    flatness = librosa.feature.spectral_flatness(y=y)
+    mfcc = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13)
+
+    _summarise_feature(rms, "rms", features)
+    _summarise_feature(zcr, "zcr", features)
+    _summarise_feature(centroid, "spectral_centroid", features)
+    _summarise_feature(bandwidth, "spectral_bandwidth", features)
+    _summarise_feature(rolloff, "spectral_rolloff", features)
+    _summarise_feature(flatness, "spectral_flatness", features)
+
+    for idx in range(mfcc.shape[0]):
+        coeff = mfcc[idx]
+        prefix = f"mfcc_{idx:02d}"
+        features[f"{prefix}_mean"] = float(np.mean(coeff))
+        features[f"{prefix}_std"] = float(np.std(coeff))
+
+    anomaly_flags = EvpAnomalyFlags(
+        is_silent=features["rms_mean"] < 1e-3,
+        possible_clipping=peak >= 0.98,
+        high_noise=features["spectral_flatness_mean"] > 0.4,
+    )
+
+    return EvpFeatureSet(
+        sample_rate=sr,
+        duration=duration,
+        features=features,
+        anomaly_flags=anomaly_flags,
+    )

--- a/packages/audio/requirements.txt
+++ b/packages/audio/requirements.txt
@@ -1,0 +1,4 @@
+librosa>=0.10,<0.11
+Resemblyzer>=0.1.3,<0.2
+openai-whisper>=20231117
+soundfile>=0.12

--- a/packages/audio/transcribe.py
+++ b/packages/audio/transcribe.py
@@ -1,0 +1,282 @@
+"""Transcription helpers for interfacing with Whisper implementations."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+PathLike = Union[str, os.PathLike[str]]
+
+DISCLAIMER = "Transcription may be inaccurate."
+
+
+@dataclass(slots=True)
+class Segment:
+    """A lightweight representation of a transcript segment."""
+
+    start: float
+    end: float
+    text: str
+    speaker: Optional[str] = None
+
+
+@dataclass(slots=True)
+class TranscriptionResult:
+    """Standard transcription payload consumed by the API lane."""
+
+    text: str
+    segments: List[Segment]
+    language: Optional[str]
+    engine: str
+    disclaimer: str = DISCLAIMER
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _import_whisper(module_override: Any = None) -> Any:
+    """Import the python ``whisper`` package lazily.
+
+    Parameters
+    ----------
+    module_override:
+        Optional module instance supplied during testing to avoid runtime imports.
+
+    Returns
+    -------
+    Module
+        The whisper module.
+
+    Raises
+    ------
+    RuntimeError
+        If the whisper package is not available.
+    """
+
+    if module_override is not None:
+        return module_override
+    try:
+        import whisper  # type: ignore[import]
+    except ImportError as exc:  # pragma: no cover - dependency missing
+        raise RuntimeError(
+            "The 'whisper' package is required for python-based transcription. "
+            "Install it via 'pip install openai-whisper'."
+        ) from exc
+    return whisper
+
+
+def transcribe_with_python_whisper(
+    audio_path: PathLike,
+    *,
+    model_name: str = "base",
+    model_dir: Optional[PathLike] = None,
+    language: Optional[str] = None,
+    temperature: float = 0.0,
+    whisper_module: Any | None = None,
+    decode_options: Optional[Dict[str, Any]] = None,
+) -> TranscriptionResult:
+    """Run transcription using the python ``whisper`` package.
+
+    The function intentionally keeps parameters explicit so the BACKEND_API lane
+    can pass deterministic decoding arguments. Callers may specify a custom
+    ``download_root`` directory through ``model_dir`` to keep all assets offline.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio clip to transcribe.
+    model_name:
+        Whisper model identifier (e.g. ``base.en``).
+    model_dir:
+        Optional directory containing pre-downloaded model weights.
+    language:
+        Force transcription language. ``None`` enables automatic detection.
+    temperature:
+        Decoding temperature forwarded to Whisper.
+    whisper_module:
+        Optional module override primarily intended for unit tests.
+    decode_options:
+        Additional keyword arguments forwarded to ``model.transcribe``.
+
+    Returns
+    -------
+    TranscriptionResult
+        Parsed transcription output compatible with API payloads.
+    """
+
+    whisper = _import_whisper(whisper_module)
+    model = whisper.load_model(
+        model_name,
+        download_root=str(model_dir) if model_dir is not None else None,
+    )
+    options: Dict[str, Any] = {
+        "temperature": temperature,
+        "condition_on_previous_text": False,
+    }
+    if decode_options:
+        options.update(decode_options)
+    if language:
+        options["language"] = language
+
+    raw_result: Dict[str, Any] = model.transcribe(str(audio_path), **options)
+    segments = [
+        Segment(
+            start=float(segment.get("start", 0.0)),
+            end=float(segment.get("end", 0.0)),
+            text=str(segment.get("text", "")).strip(),
+            speaker=None,
+        )
+        for segment in raw_result.get("segments", [])
+    ]
+    text = raw_result.get("text", "").strip()
+    metadata = {
+        "temperature": options.get("temperature"),
+        "model": model_name,
+        "duration": raw_result.get("duration"),
+        "language_probability": raw_result.get("language_probability"),
+    }
+    detected_language = raw_result.get("language") or language
+    return TranscriptionResult(
+        text=text,
+        segments=segments,
+        language=detected_language,
+        engine="python-whisper",
+        metadata=metadata,
+    )
+
+
+def _build_whisper_cpp_command(
+    binary_path: Path,
+    audio_path: Path,
+    model_path: Path,
+    *,
+    language: Optional[str],
+    temperature: float,
+    threads: Optional[int],
+    beam_size: Optional[int],
+    extra_args: Optional[Sequence[str]] = None,
+    output_dir: Optional[Path] = None,
+) -> List[str]:
+    cmd: List[str] = [str(binary_path), "--model", str(model_path), "--output-json"]
+    if output_dir is not None:
+        cmd.extend(["--output-dir", str(output_dir)])
+    if language:
+        cmd.extend(["--language", language])
+    cmd.extend(["--temperature", f"{temperature:.2f}"])
+    if threads:
+        cmd.extend(["--threads", str(threads)])
+    if beam_size:
+        cmd.extend(["--beam-size", str(beam_size)])
+    cmd.append(str(audio_path))
+    if extra_args:
+        cmd.extend(list(extra_args))
+    return cmd
+
+
+def transcribe_with_whisper_cpp(
+    audio_path: PathLike,
+    *,
+    binary_path: PathLike,
+    model_path: PathLike,
+    language: Optional[str] = None,
+    temperature: float = 0.0,
+    threads: Optional[int] = None,
+    beam_size: Optional[int] = None,
+    extra_args: Optional[Sequence[str]] = None,
+    working_dir: Optional[PathLike] = None,
+    env: Optional[Dict[str, str]] = None,
+) -> TranscriptionResult:
+    """Execute a whisper.cpp binary and normalise its JSON output.
+
+    The function expects a whisper.cpp build compiled with ``--output-json``
+    support. It writes temporary results to ``working_dir`` when provided or a
+    newly created temporary directory otherwise.
+    """
+
+    audio_path = Path(audio_path)
+    binary_path = Path(binary_path)
+    model_path = Path(model_path)
+    if not audio_path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+    if not binary_path.exists():
+        raise FileNotFoundError(f"whisper.cpp binary not found: {binary_path}")
+    if not model_path.exists():
+        raise FileNotFoundError(f"whisper.cpp model not found: {model_path}")
+
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        output_dir: Path
+        if working_dir is None:
+            temp_dir = tempfile.TemporaryDirectory(prefix="whispercpp_")
+            output_dir = Path(temp_dir.name)
+        else:
+            output_dir = Path(working_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = _build_whisper_cpp_command(
+            binary_path=binary_path,
+            audio_path=audio_path,
+            model_path=model_path,
+            language=language,
+            temperature=temperature,
+            threads=threads,
+            beam_size=beam_size,
+            extra_args=extra_args,
+            output_dir=output_dir,
+        )
+
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                "whisper.cpp execution failed",
+                {
+                    "command": cmd,
+                    "stdout": completed.stdout,
+                    "stderr": completed.stderr,
+                },
+            )
+
+        json_files = sorted(output_dir.glob("*.json"))
+        if not json_files:
+            raise RuntimeError(
+                "whisper.cpp did not emit JSON output; enable '--output-json' in the binary."
+            )
+        with json_files[0].open("r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+
+        segments = [
+            Segment(
+                start=float(segment.get("start", 0.0)),
+                end=float(segment.get("end", 0.0)),
+                text=str(segment.get("text", "")).strip(),
+                speaker=None,
+            )
+            for segment in payload.get("segments", [])
+        ]
+        metadata = {
+            "command": cmd,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+        text = payload.get("text", "").strip()
+        detected_language = payload.get("language") or language
+
+        return TranscriptionResult(
+            text=text,
+            segments=segments,
+            language=detected_language,
+            engine="whisper.cpp",
+            metadata=metadata,
+        )
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()

--- a/tests/audio/test_evp.py
+++ b/tests/audio/test_evp.py
@@ -1,0 +1,46 @@
+"""Tests for EVP feature extraction utilities."""
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+
+import pytest
+
+from packages.audio.evp import extract_evp_features
+
+
+@pytest.fixture(scope="module")
+def generated_tone_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a temporary sine wave recording for EVP feature tests."""
+
+    pytest.importorskip("librosa")
+    numpy = pytest.importorskip("numpy")
+
+    sample_rate = 16_000
+    duration_seconds = 1.0
+    t = numpy.arange(int(sample_rate * duration_seconds)) / sample_rate
+    waveform = 0.2 * numpy.sin(2 * numpy.pi * 440.0 * t)
+
+    scaled = numpy.clip(waveform, -1.0, 1.0)
+    int_samples = (scaled * 32767).astype("<i2")
+
+    audio_dir = tmp_path_factory.mktemp("audio")
+    file_path = audio_dir / "tone.wav"
+    with wave.open(str(file_path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(int_samples.tobytes())
+
+    return file_path
+
+
+def test_extract_evp_features_has_expected_structure(generated_tone_path: Path) -> None:
+    result = extract_evp_features(generated_tone_path)
+
+    assert result.sample_rate == 16_000
+    assert result.duration > 0.5
+    assert "mfcc_00_mean" in result.features
+    assert not result.anomaly_flags.is_silent
+    assert isinstance(result.anomaly_flags.high_noise, bool)
+    assert result.disclaimer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for shared fixtures and path setup."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure the whisper.cpp transcription wrapper cleans up temporary directories even when errors occur
- replace the committed EVP audio fixture with an on-the-fly sine wave generator so no binary assets are needed

## Testing
- `scripts/verify-structure.sh`
- `ruff check packages/audio tests/audio`
- `pytest tests/audio --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68cc930b2fd88327ab8f7da7a64e1853